### PR TITLE
Fix bug in SoundPool stop and stop_looping functions

### DIFF
--- a/mpfmc/assets/sound.py
+++ b/mpfmc/assets/sound.py
@@ -47,12 +47,14 @@ class SoundPool(AssetPool):
         Stops all instances of all sounds contained in the sound pool.
         """
         for sound in self.assets:
-            sound.stop()
+            # Assets contain a list of tuples (sound, number)
+            sound[0].stop()
 
     def stop_looping(self):
         """Stops looping on all instances of all sounds contained in the sound pool."""
         for sound in self.assets:
-            sound.stop_looping(self)
+            # Assets contain a list of tuples (sound, number)
+            sound[0].stop_looping()
 
 
 class SoundAsset(Asset):

--- a/mpfmc/tests/machine_files/audio/modes/mode1/config/mode1.yaml
+++ b/mpfmc/tests/machine_files/audio/modes/mode1/config/mode1.yaml
@@ -5,3 +5,5 @@ mode:
 
 sound_player:
     play_sound_synthping_in_mode: 210871_synthping
+    play_sound_drum_group_in_mode: drum_group
+

--- a/mpfmc/tests/test_Audio.py
+++ b/mpfmc/tests/test_Audio.py
@@ -186,7 +186,13 @@ class TestAudio(MpfMcTestCase):
             self.mc.events.post('play_sound_drum_group')
             self.advance_time(0.1)
 
+        self.mc.events.post('play_sound_drum_group_in_mode')
+
         self.advance_time(1)
+
+        # Test stopping the mode
+        self.send(bcp_command='mode_stop', name='mode1')
+        self.advance_time()
 
         # Test sound events
         self.mc.bcp_processor.send.assert_any_call('trigger', name='moron_test_played')


### PR DESCRIPTION
Fixed a bug that was triggered by stopping a mode that had played a sound pool using the sound_player. The stop() and stop_looping() functions in the SoundPool class did not reference the sounds properly. Added test for the bug.

Supercedes PR #92 (targeted wrong branch)
