### PR TITLE
fixed order of widgets at the with the same z value from config

### DIFF
--- a/mpfmc/config_collections/widget.py
+++ b/mpfmc/config_collections/widget.py
@@ -46,8 +46,6 @@ class Widget(ConfigCollection):
         if isinstance(config, dict):
             config = [config]
 
-        config.reverse()
-
         widget_list = list()
 
         for widget in config:

--- a/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
+++ b/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
@@ -258,19 +258,87 @@ slide_player:
       - type: text
         text: WIDGET REPLACEMENT
         y: 25%
-#      - key: box11
-#        type: text
-#        text: box11
-#        x: 260
-#      - key: box12
-#        type: text
-#        text: box12
-#        x: 180
-#      - key: box13
-#        type: text
-#        text: box13
-#        x: 100
-#      - key: box14
-#        type: text
-#        text: box14
-#        x: 20
+  show_slide_with_widgets:
+    slide_1:
+      - type: text
+        text: widget4.1
+        y: 300
+        z: 1
+        color: ff0000
+        font_size: 100
+      - type: text
+        text: widget4.2
+        z: 1000
+        y: 250
+        color: ffff00
+        font_size: 100
+      - type: text
+        text: widget4.3
+        y: 200
+        color: 00ff00
+        font_size: 100
+      - type: text
+        text: widget4.4
+        z: 1
+        y: 150
+        color: 00ffff
+        font_size: 100
+      - type: text
+        text: widget4.5
+        z: 1000
+        y: 100
+        color: 0000ff
+        font_size: 100
+      - type: text
+        text: widget4.6
+        color: ff00ff
+        font_size: 100
+        y: 50
+      - type: text
+        text: widget4.7
+        y: 0
+        color: 888888
+        font_size: 100
+  show_slide_with_lots_of_widgets: slide_with_lots_of_widgets
+
+slides:
+    slide_with_lots_of_widgets:
+      - type: text
+        text: widget4.1
+        y: 300
+        z: 1
+        color: ff0000
+        font_size: 100
+      - type: text
+        text: widget4.2
+        z: 1000
+        y: 250
+        color: ffff00
+        font_size: 100
+      - type: text
+        text: widget4.3
+        y: 200
+        color: 00ff00
+        font_size: 100
+      - type: text
+        text: widget4.4
+        z: 1
+        y: 150
+        color: 00ffff
+        font_size: 100
+      - type: text
+        text: widget4.5
+        z: 1000
+        y: 100
+        color: 0000ff
+        font_size: 100
+      - type: text
+        text: widget4.6
+        color: ff00ff
+        font_size: 100
+        y: 50
+      - type: text
+        text: widget4.7
+        y: 0
+        color: 888888
+        font_size: 100

--- a/mpfmc/tests/test_Widget.py
+++ b/mpfmc/tests/test_Widget.py
@@ -23,22 +23,22 @@ class TestWidget(MpfMcTestCase):
         self.assertIs(type(self.mc.widgets['widget3']), list)
         self.assertEqual(len(self.mc.widgets['widget3']), 3)
 
-        # Ensure they're in order. Order is the order they're drawn,
-        # so the highest priority one is last. We don't care about z values
-        # at this point since those are threaded in when the widgets are
-        # added to the slides, but we want to make sure that widgets of the
-        # same z are in the order based on their order in the config file.
+        # Ensure they're in order. Order is the order they're drawn. We don't
+        # care about z values at this point since those are threaded in when
+        # the widgets are added to the slides, but we want to make sure that
+        # widgets of the same z are in the order based on their order in the
+        # config file.
         self.assertEqual(self.mc.widgets['widget3'][0]['text'],
-                         'widget3.3')
+                         'widget3.1')
         self.assertEqual(self.mc.widgets['widget3'][1]['text'],
                          'widget3.2')
         self.assertEqual(self.mc.widgets['widget3'][2]['text'],
-                         'widget3.1')
+                         'widget3.3')
 
         # List with multiple items and custom z orders
         self.assertIn('widget4', self.mc.widgets)
 
-    def test_adding_widgets_to_slide(self):
+    def test_widget_z_order_from_named_widget(self):
         self.mc.targets['default'].add_slide(name='slide1')
         self.mc.targets['default'].show_slide('slide1')
         self.assertEqual(self.mc.targets['default'].current_slide_name,
@@ -59,7 +59,7 @@ class TestWidget(MpfMcTestCase):
         # Order should be by z order (highest first), then by order in the
         # config. The entire list should be backwards, lowest, priority first.
 
-        target_order = ['4.7', '4.6', '4.3', '4.4', '4.1', '4.5', '4.2']
+        target_order = ['4.3', '4.6', '4.7', '4.1', '4.4', '4.2', '4.5']
         for widget, index in zip(
                 self.mc.targets['default'].current_slide.children[0].children,
                 target_order):
@@ -69,8 +69,56 @@ class TestWidget(MpfMcTestCase):
         self.mc.targets['default'].current_slide.add_widgets_from_library(
                 'widget5')
 
-        # should be inserted between 4.1 and 4.5
-        target_order = ['4.7', '4.6', '4.3', '4.4', '4.1', '5', '4.5', '4.2']
+        # should be inserted between 4.4 and 4.2
+        target_order = ['4.3', '4.6', '4.7', '4.1', '4.4', '5', '4.2', '4.5']
+        for widget, index in zip(
+                self.mc.targets['default'].current_slide.children[0].children,
+                target_order):
+            self.assertEqual(widget.text, 'widget{}'.format(index))
+
+    def test_widget_z_order_from_slide_player(self):
+        self.mc.events.post('show_slide_with_widgets')
+        self.advance_time()
+        self.assertEqual(self.mc.targets['default'].current_slide_name,
+                         'slide_1')
+
+        # initial order & z orders from config
+        # 4.1 / 1
+        # 4.2 / 1000
+        # 4.3 / None
+        # 4.4 / 1
+        # 4.5 / 1000
+        # 4.6 / None
+        # 4.7 / None
+
+        # Order should be by z order (highest first), then by order in the
+        # config. The entire list should be backwards, lowest, priority first.
+
+        target_order = ['4.3', '4.6', '4.7', '4.1', '4.4', '4.2', '4.5']
+        for widget, index in zip(
+                self.mc.targets['default'].current_slide.children[0].children,
+                target_order):
+            self.assertEqual(widget.text, 'widget{}'.format(index))
+
+    def test_widget_z_order_from_named_slide(self):
+        self.mc.events.post('show_slide_with_lots_of_widgets')
+        self.advance_time()
+        self.assertEqual(self.mc.targets['default'].current_slide_name,
+                         'slide_with_lots_of_widgets')
+
+        # initial order & z orders from config
+        # 4.1 / 1
+        # 4.2 / 1000
+        # 4.3 / None
+        # 4.4 / 1
+        # 4.5 / 1000
+        # 4.6 / None
+        # 4.7 / None
+
+        # Order should be by z order (highest first), then by order in the
+        # config. The entire list should be backwards, lowest, priority first.
+
+        target_order = ['4.3', '4.6', '4.7', '4.1', '4.4', '4.2', '4.5']
         for widget, index in zip(
                 self.mc.targets['default'].current_slide.children[0].children,
                 target_order):


### PR DESCRIPTION
Added tests to confirm this works with named widgets, named slides, and
in slide_player dynamically created slides

fixes #165
