### PR TITLE
Widget z order refix

### DIFF
--- a/mpfmc/config_collections/widget.py
+++ b/mpfmc/config_collections/widget.py
@@ -80,6 +80,17 @@ class Widget(ConfigCollection):
         else:
             config['animations'] = None
 
+        if config.get('z', 0) < 0:
+            raise ValueError(
+                "\nWidget with negative z value in config: {}.\n\nAs of MPF "
+                "v0.30.3, negative z: "
+                "values are no longer used to put widgets in 'parent' frames. "
+                "Instead add a 'target:' setting to the 'widget_player:' entry"
+                " and set that to the name of the display target (display or "
+                "slide_frame) you want to add this widget to. Note that "
+                "'target: default' is valid and will add the widget to the "
+                "default display on top of any slides.\n".format(config))
+
         return config
 
     def _register_trigger(self, event_name, **kwargs):

--- a/mpfmc/config_players/slide_player.py
+++ b/mpfmc/config_players/slide_player.py
@@ -146,13 +146,15 @@ class McSlidePlayer(McConfigPlayer):
                     target = self.machine.targets[target_name]
                 except KeyError:
                     # target does not exist yet. perform action when it appears
-                    self._delayed_actions(target_name, s, slide, instance_dict, full_context)
+                    self._delayed_actions(target_name, s, slide, instance_dict,
+                                          full_context)
                     return
             else:
                 target = self.machine.targets['default']
                 target_name = "default"
 
-            self._delayed_actions(target_name, s, slide, instance_dict, full_context)
+            self._delayed_actions(target_name, s, slide, instance_dict,
+                                  full_context)
 
             # remove target
             s.pop("target")
@@ -160,7 +162,8 @@ class McSlidePlayer(McConfigPlayer):
             if s['action'] == 'play':
                 # is this a named slide, or a new slide?
                 if 'widgets' in s:
-                    target.add_and_show_slide(key=full_context, slide_name=slide, **s)
+                    target.add_and_show_slide(key=full_context,
+                                              slide_name=slide, **s)
                 else:
                     target.show_slide(slide_name=slide, key=full_context, **s)
 

--- a/mpfmc/tests/machine_files/shapes/config/test_shapes.yaml
+++ b/mpfmc/tests/machine_files/shapes/config/test_shapes.yaml
@@ -9,7 +9,7 @@ slides:
   slide1:
     - type: points
       points: 50, 50, 75, 50, 100, 30, 200, 50, 68, 250
-      size: 3
+      pointsize: 3
     - type: line
       points: 0, 0, 100, 100, 100, 200
       color: 00ff00
@@ -30,7 +30,7 @@ slides:
       height: 100
       color: purple
       angle_start: 0
-      angle_end: 90
+      angle_end: 45
     - type: rectangle
       x: 250
       y: 125

--- a/mpfmc/tests/machine_files/slide_frame/config/test_slide_frame.yaml
+++ b/mpfmc/tests/machine_files/slide_frame/config/test_slide_frame.yaml
@@ -11,25 +11,36 @@ slides:
     width: 200
     height: 100
     name: frame1
-    y: 100%
-    anchor_y: top
-    x: 100%
-    anchor_x: right
+    y: 50
+    x: 50
+    anchor_y: bottom
+    anchor_x: left
   - type: text
-    text: SLIDE FRAME BASE
-    font_size: 100
+    text: SLIDE FRAME IN SLIDE 1
+    font_size: 20
+    y: bottom
+    anchor_y: bottom
   frame1_text:
   - type: text
-    text: TEXT IN FRAME
-    color: 00ff00
-    font_size: 200
+    text: SLIDE 1 IN FRAME
+    color: lime
+    font_size: 10
+  - type: rectangle
+    width: 200
+    height: 100
+    color: 550000
   frame1_text2:
   - type: text
-    text: MORE TEXT
-    color: 00ffff
-    font_size: 100
+    text: SLIDE 2 IN FRAME
+    color: black
+    font_size: 10
+  - type: rectangle
+    width: 200
+    height: 100
+    color: 00ff00
 
 slide_player:
+  show_slide1: slide1
   show_frame_text:
     frame1_text:
       target: frame1

--- a/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
+++ b/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
@@ -83,7 +83,7 @@ widgets:
   widget6:
     type: text
     text: widget6
-    z: -100
+    z: 100
     color: 774303
     font_size: 100
   widget7:
@@ -123,7 +123,9 @@ widget_player:
   add_widget2_to_slide1:
     widget2:
       slide: slide1
-  add_widget6: widget6
+  add_widget6:
+    widget6:
+      target: default
   remove_widget1_by_key:
     widget1:
       action: remove
@@ -136,6 +138,11 @@ widget_player:
       widget8:
         widget_settings:
           expire: 1s
+  add_widget8_expire_parent:
+      widget8:
+        widget_settings:
+          expire: 1s
+        target: default
   add_widget8_custom_settings:
       widget8:
         widget_settings:
@@ -199,11 +206,12 @@ widget_player:
         color: red
   widget_to_parent:
     box11:
+      target: default
       widget_settings:
-        z: -1
+        z: 1
     box12:
       widget_settings:
-        z: -2
+        z: 2
         color: red
         y: middle+2
   show_christmas_slide_full:
@@ -300,6 +308,13 @@ slide_player:
         color: 888888
         font_size: 100
   show_slide_with_lots_of_widgets: slide_with_lots_of_widgets
+  show_new_slide:
+    new_slide2:
+      widgets:
+      - type: text
+        text: NEW SLIDE
+        y: 0
+        anchor_y: bottom
 
 slides:
     slide_with_lots_of_widgets:

--- a/mpfmc/tests/machine_files/widgets/modes/mode1/config/mode1.yaml
+++ b/mpfmc/tests/machine_files/widgets/modes/mode1/config/mode1.yaml
@@ -5,7 +5,9 @@ mode:
 
 widget_player:
   mode1_add_widgets: widget2
-  mode1_add_widget6: widget6
+  mode1_add_widget6:
+    widget6:
+      target: default
   mode1_add_widget_with_key:
     widget2:
       key: newton_crosby

--- a/mpfmc/tests/test_SlideFrame.py
+++ b/mpfmc/tests/test_SlideFrame.py
@@ -14,7 +14,8 @@ class TestSlideFrame(MpfMcTestCase):
         self.mc.targets['default'].add_slide(name='slide1',
                                              config=self.mc.slides[
                                                  'slide1'])
-        self.mc.targets['default'].show_slide('slide1')
+        self.mc.events.post('show_slide1')
+        self.advance_time()
 
         # make sure our slide frame is a valid target
         self.assertIn('frame1', self.mc.targets)
@@ -41,11 +42,11 @@ class TestSlideFrame(MpfMcTestCase):
 
         # make sure the slide frame is the right size and in the right pos
         self.assertEqual(frame1_frame.size, [200, 100])
-        self.assertEqual(frame1_frame.pos, [200, 200])
+        self.assertEqual(frame1_frame.pos, [50, 50])
 
         # it's parent should be the same size and pos
         self.assertEqual(frame1_frame_parent.size, [200, 100])
-        self.assertEqual(frame1_frame_parent.pos, [200, 200])
+        self.assertEqual(frame1_frame_parent.pos, [50, 50])
 
         # it's parent's parent is the display
         self.assertEqual(frame1_frame_parent.parent.size, [400, 300])
@@ -53,29 +54,29 @@ class TestSlideFrame(MpfMcTestCase):
 
         # add a widget to the frame
         self.mc.events.post('show_frame_text')
-        self.advance_time()
+        self.advance_time(1)
 
         # make sure the text is in the frame
         self.assertEqual(
             frame1_frame.current_slide.children[0].children[0].text,
-            'TEXT IN FRAME')
+            'SLIDE 1 IN FRAME')
 
         # flip frame to a different slide
         self.mc.events.post('show_frame_text2')
-        self.advance_time()
+        self.advance_time(1)
 
         # make sure the next text is there
         self.assertEqual(
             frame1_frame.current_slide.children[0].children[0].text,
-            'MORE TEXT')
+            'SLIDE 2 IN FRAME')
 
         # flip back to the first frame and make sure that text is there
         self.mc.events.post('show_frame_text')
-        self.advance_time()
+        self.advance_time(1)
 
         self.assertEqual(
             frame1_frame.current_slide.children[0].children[0].text,
-            'TEXT IN FRAME')
+            'SLIDE 1 IN FRAME')
 
     def test_remove_non_existent_slide(self):
         self.assertFalse(self.mc.targets['default'].remove_slide('hello'))

--- a/mpfmc/tests/test_Widget.py
+++ b/mpfmc/tests/test_Widget.py
@@ -57,9 +57,9 @@ class TestWidget(MpfMcTestCase):
         # 4.7 / None
 
         # Order should be by z order (highest first), then by order in the
-        # config. The entire list should be backwards, lowest, priority first.
+        # config.
 
-        target_order = ['4.3', '4.6', '4.7', '4.1', '4.4', '4.2', '4.5']
+        target_order = ['4.2', '4.5', '4.1', '4.4', '4.3', '4.6', '4.7']
         for widget, index in zip(
                 self.mc.targets['default'].current_slide.children[0].children,
                 target_order):
@@ -69,8 +69,8 @@ class TestWidget(MpfMcTestCase):
         self.mc.targets['default'].current_slide.add_widgets_from_library(
                 'widget5')
 
-        # should be inserted between 4.4 and 4.2
-        target_order = ['4.3', '4.6', '4.7', '4.1', '4.4', '5', '4.2', '4.5']
+        # should be inserted between 4.5 and 4.1
+        target_order = ['4.2', '4.5', '5', '4.1', '4.4', '4.3', '4.6', '4.7']
         for widget, index in zip(
                 self.mc.targets['default'].current_slide.children[0].children,
                 target_order):
@@ -92,9 +92,9 @@ class TestWidget(MpfMcTestCase):
         # 4.7 / None
 
         # Order should be by z order (highest first), then by order in the
-        # config. The entire list should be backwards, lowest, priority first.
+        # config.
 
-        target_order = ['4.3', '4.6', '4.7', '4.1', '4.4', '4.2', '4.5']
+        target_order = ['4.2', '4.5', '4.1', '4.4', '4.3', '4.6', '4.7']
         for widget, index in zip(
                 self.mc.targets['default'].current_slide.children[0].children,
                 target_order):
@@ -116,9 +116,9 @@ class TestWidget(MpfMcTestCase):
         # 4.7 / None
 
         # Order should be by z order (highest first), then by order in the
-        # config. The entire list should be backwards, lowest, priority first.
+        # config.
 
-        target_order = ['4.3', '4.6', '4.7', '4.1', '4.4', '4.2', '4.5']
+        target_order = ['4.2', '4.5', '4.1', '4.4', '4.3', '4.6', '4.7']
         for widget, index in zip(
                 self.mc.targets['default'].current_slide.children[0].children,
                 target_order):

--- a/mpfmc/uix/slide.py
+++ b/mpfmc/uix/slide.py
@@ -6,6 +6,7 @@ from kivy.uix.screenmanager import Screen
 from kivy.uix.stencilview import StencilView
 
 from mpfmc.core.utils import set_position
+from mpfmc.uix.widget import create_widget_objects_from_config
 
 
 class Slide(Screen):
@@ -54,13 +55,17 @@ class Slide(Screen):
         super().add_widget(self.stencil)
 
         if 'widgets' in config:  # don't want try, swallows too much
-            self.add_widgets_from_config(config=config['widgets'],
-                                         key=self.key,
-                                         play_kwargs=play_kwargs)
+
+            widgets = create_widget_objects_from_config(
+                mc=self.mc,
+                config=config['widgets'], key=self.key,
+                play_kwargs=play_kwargs)
+
+            self.add_widgets(widgets)
 
         self.mc.active_slides[name] = self
         target.add_widget(self)
-        mc.slides[name] = config
+        self.mc.slides[name] = config
 
         bg = config.get('background_color', [0.0, 0.0, 0.0, 1.0])
         if bg != [0.0, 0.0, 0.0, 0.0]:
@@ -164,6 +169,10 @@ class Slide(Screen):
 
         return widgets_added
 
+    def add_widgets(self, widgets):
+        for w in widgets:
+            self.add_widget(w)
+
     def add_widget(self, widget, **kwargs):
         """Adds a widget to this slide.
 
@@ -222,11 +231,6 @@ class Slide(Screen):
 
         Widgets added to the parent slide_frame stay active and visible even
         if the slide in the frame changes.
-
-        Note that negative z-order values tell the widget it should be applied
-        to the parent frame instead of the slide, but the absolute value of the
-        values is used to control their z-order. e.g. -100 widget shows on top
-        of a -50 widget.
 
         """
         self.manager.parent.parent.add_widget(widget)

--- a/mpfmc/uix/slide_frame.py
+++ b/mpfmc/uix/slide_frame.py
@@ -27,6 +27,7 @@ class SlideFrameParent(MpfWidget, FloatLayout):
         self.mc = mc
         self.name = slide_frame.name
         self.config = config
+        self.slide_frame = slide_frame
 
         self.ready = False
         self.size_hint = (None, None)
@@ -40,20 +41,21 @@ class SlideFrameParent(MpfWidget, FloatLayout):
         super().add_widget(self.stencil)
         self.add_widget(slide_frame)
 
-        self.stencil.pos = set_position(self.width, self.height,
-                                slide_frame.native_size[0],
-                                slide_frame.native_size[1],
-                                slide_frame.config['x'],
-                                slide_frame.config['y'],
-                                slide_frame.config['anchor_x'],
-                                slide_frame.config['anchor_y'])
-
     def __repr__(self):
         return '<SlideFrameParent name={}, parent={}>'.format(self.name,
                                                               self.parent)
 
-    # def __lt__(self, other):
-    #     return self.stencil.config['z'] < other.stencil.config['z']
+    def on_pos(self, *args):
+        self.pos = set_position(self.parent.width,
+                                        self.parent.height,
+                        self.width, self.height,
+                        self.slide_frame.config['x'],
+                        self.slide_frame.config['y'],
+                        self.slide_frame.config['anchor_x'],
+                        self.slide_frame.config['anchor_y'])
+
+        self.stencil.pos = self.pos
+        self.slide_frame.pos = self.pos
 
     def add_widget(self, widget, **kwargs):
         del kwargs
@@ -76,7 +78,7 @@ class SlideFrame(MpfWidget, ScreenManager):
     """A widget which displays slides."""
 
     # pylint: disable-msg=too-many-arguments
-    def __init__(self, mc, name=None, config=None, slide=None, key=None, play_kwargs=None):
+    def __init__(self, mc, name=None, config=None, key=None, play_kwargs=None):
         del play_kwargs
         self.name = name  # needs to be set before super()
         # If this is a the main SlideFrame of a display, it will get its size
@@ -85,10 +87,9 @@ class SlideFrame(MpfWidget, ScreenManager):
         try:
             self.native_size = (config['width'], config['height'])
         except (KeyError, TypeError):
-            self.native_size = self.slide.native_size
+            self.native_size = self.parent.native_size
 
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
-        self.slide_frame_parent = None
+        super().__init__(mc=mc, config=config, key=key)
 
         # minimal config needed if this is a widget
         if not config:
@@ -365,3 +366,17 @@ class SlideFrame(MpfWidget, ScreenManager):
                 new_slide = s
 
         return new_slide
+
+    def add_widget_to_frame(self, widget):
+        self.parent.parent.add_widget(widget)
+
+    def add_widgets_to_frame(self, widgets):
+        for w in widgets:
+            self.add_widget_to_frame(w)
+
+    def remove_widgets_by_key(self, key):
+        for widget in self.get_widgets_by_key(key):
+            self.parent.parent.remove_widget(widget)
+
+    def get_widgets_by_key(self, key):
+        return [x for x in self.parent.children if x.key == key]

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -129,7 +129,7 @@ class MpfWidget(object):
         return '<{} Widget id={}>'.format(self.widget_type_name, self.id)
 
     def __lt__(self, other):
-        return self.config['z'] < other.config['z']
+        return other.config['z'] < self.config['z']
 
     # todo change to classmethod
     def _set_default_style(self):

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -19,6 +19,63 @@ are not real MPF events, rather, they're used to trigger animations from
 things the slide is doing."""
 
 
+def create_widget_objects_from_config(mc, config, key=None, play_kwargs=None,
+                                      widget_settings=None):
+
+    if not isinstance(config, list):
+        config = [config]
+    widgets_added = list()
+
+    if not play_kwargs:
+        play_kwargs = dict()  # todo
+
+    for widget in config:
+
+        if widget_settings:
+            widget_settings = mc.config_validator.validate_config(
+                'widgets:{}'.format(widget['type']), widget_settings,
+                base_spec='widgets:common', add_missing_keys=False)
+
+            widget.update(widget_settings)
+
+        configured_key = widget.get('key', None)
+
+        if (configured_key and key and "." not in key and
+                configured_key != key):
+            raise KeyError("Widget has incoming key '{}' which does not "
+                           "match the key in the widget's config "
+                           "'{}'.".format(key, configured_key))
+
+        if configured_key:
+            this_key = configured_key
+        else:
+            this_key = key
+
+        widget_obj = mc.widgets.type_map[widget['type']](
+            mc=mc, config=widget, key=this_key, play_kwargs=play_kwargs)
+
+        top_widget = widget_obj
+
+        # some widgets (like slide frames) have parents, so we need to make
+        # sure that we add the parent widget to the slide
+        while top_widget.parent:
+            top_widget = top_widget.parent
+
+        widgets_added.append(top_widget)
+
+    return widgets_added
+
+
+def create_widget_objects_from_library(mc, name, key=None,
+        widget_settings=None, play_kwargs=None, **kwargs):
+        if name not in mc.widgets:
+            raise ValueError("Widget %s not found", name)
+
+        return create_widget_objects_from_config(mc=mc,
+            config=mc.widgets[name], key=key, widget_settings=widget_settings,
+                                                 play_kwargs=play_kwargs)
+
+
 class MpfWidget(object):
     """Mixin class that's used to extend all the Kivy widget base classes with
     a few extra attributes and methods we need for everything to work with MPF.
@@ -37,13 +94,11 @@ class MpfWidget(object):
 
     merge_settings = tuple()
 
-    def __init__(self, mc, slide=None, config=None, key=None, **kwargs):
+    def __init__(self, mc, config=None, key=None, **kwargs):
         del kwargs
         self.size_hint = (None, None)
 
         super().__init__()
-
-        self.slide = slide
 
         self.config = deepcopy(config)
         # needs to be deepcopy since configs can have nested dicts
@@ -60,19 +115,9 @@ class MpfWidget(object):
         # dict of original values of settings that were animated so we can
         # restore them later
 
-        self._default_style = None
+        self._percent_prop_dicts = dict()
 
-        # some attributes can be expressed in percentages. This dict holds
-        # those, key is attribute name, val is max value
-        try:
-            self._percent_prop_dicts = dict(x=slide.width,
-                                            y=slide.height,
-                                            width=slide.width,
-                                            height=slide.height,
-                                            opacity=1,
-                                            line_height=1)
-        except AttributeError:
-            self._percent_prop_dicts = dict()
+        self._default_style = None
 
         self._set_default_style()
         self._apply_style()
@@ -197,6 +242,21 @@ class MpfWidget(object):
         except AttributeError:
             pass
 
+    def on_pos(self, *args):
+        del args
+
+        # some attributes can be expressed in percentages. This dict holds
+        # those, key is attribute name, val is max value
+        try:
+            self._percent_prop_dicts = dict(x=self.parent.width,
+                                            y=self.parent.height,
+                                            width=self.parent.width,
+                                            height=self.parent.height,
+                                            opacity=1,
+                                            line_height=1)
+        except AttributeError:
+            pass
+
     def build_animation_from_config(self, config_list):
         """Build animation object from config."""
         if not isinstance(config_list, list):
@@ -278,7 +338,7 @@ class MpfWidget(object):
     def schedule_removal(self, secs):
         self.mc.clock.schedule_once(self.remove, secs)
 
-    def remove(self, dt):
+    def remove(self, *dt):
         del dt
 
         try:

--- a/mpfmc/widgets/bezier.py
+++ b/mpfmc/widgets/bezier.py
@@ -8,8 +8,8 @@ class Bezier(MpfWidget, Widget):
 
     widget_type_name = 'Line'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def __init__(self, mc, config, key=None, **kwargs):
+        super().__init__(mc=mc, config=config, key=key)
 
         with self.canvas:
             Color(*self.config['color'])

--- a/mpfmc/widgets/dmd.py
+++ b/mpfmc/widgets/dmd.py
@@ -10,8 +10,8 @@ from kivy.uix.stencilview import StencilView
 class Dmd(MpfWidget, Widget):
     widget_type_name = 'DMD'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def __init__(self, mc, config, key=None, **kwargs):
+        super().__init__(mc=mc, config=config, key=key)
 
         self.source = self.mc.displays[self.config['source_display']]
 
@@ -28,21 +28,9 @@ class Dmd(MpfWidget, Widget):
 
         self.add_widget(self.dmd_frame)
 
-        self.dmd_frame.add_widget(DmdSource(mc, config, slide, key))
+        self.dmd_frame.add_widget(DmdSource(mc, config, key))
 
         self.dmd_frame.size = self.size
-
-        self.dmd_frame.pos = set_position(slide.width,
-                                          slide.height,
-                                          self.width, self.height,
-                                          self.config['x'],
-                                          self.config['y'],
-                                          self.config['anchor_x'],
-                                          self.config['anchor_y'],
-                                          self.config['adjust_top'],
-                                          self.config['adjust_right'],
-                                          self.config['adjust_bottom'],
-                                          self.config['adjust_left'])
 
     def __repr__(self):  # pragma: no cover
         try:
@@ -51,6 +39,19 @@ class Dmd(MpfWidget, Widget):
         except AttributeError:
             return '<DMD size={}, source_size=(none)>'.format(
                     self.size)
+
+    def on_pos(self, *args):
+        self.dmd_frame.pos = set_position(self.parent.width,
+                                  self.parent.height,
+                                  self.width, self.height,
+                                  self.config['x'],
+                                  self.config['y'],
+                                  self.config['anchor_x'],
+                                  self.config['anchor_y'],
+                                  self.config['adjust_top'],
+                                  self.config['adjust_right'],
+                                  self.config['adjust_bottom'],
+                                  self.config['adjust_left'])
 
 
 class ColorDmd(Dmd):
@@ -68,8 +69,8 @@ class ColorDmd(Dmd):
 class DmdSource(MpfWidget, Scatter, Widget):
     widget_type_name = 'DMD Source'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def __init__(self, mc, config, key=None, **kwargs):
+        super().__init__(mc=mc, config=config, key=key)
 
         self.source = self.mc.displays[self.config['source_display']]
 

--- a/mpfmc/widgets/ellipse.py
+++ b/mpfmc/widgets/ellipse.py
@@ -8,26 +8,26 @@ from mpfmc.uix.widget import MpfWidget
 
 class Ellipse(MpfWidget, Widget):
 
-    widget_type_name = 'Rectangle'
+    widget_type_name = 'Ellipse'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def on_pos(self, *args):
+        del args
 
-        pos = set_position(slide.width,
-                           slide.height,
-                           self.width, self.height,
-                           self.config['x'],
-                           self.config['y'],
-                           self.config['anchor_x'],
-                           self.config['anchor_y'],
-                           self.config['adjust_top'],
-                           self.config['adjust_right'],
-                           self.config['adjust_bottom'],
-                           self.config['adjust_left'])
+        self.pos = set_position(self.parent.width,
+                                self.parent.height,
+                                self.width, self.height,
+                                self.config['x'],
+                                self.config['y'],
+                                self.config['anchor_x'],
+                                self.config['anchor_y'],
+                                self.config['adjust_top'],
+                                self.config['adjust_right'],
+                                self.config['adjust_bottom'],
+                                self.config['adjust_left'])
 
         with self.canvas:
             Color(*self.config['color'])
-            KivyEllipse(pos=pos, size=self.size,
+            KivyEllipse(pos=self.pos, size=self.size,
                         segments=self.config['segments'],
                         angle_start=self.config['angle_start'],
                         angle_end=self.config['angle_end'])

--- a/mpfmc/widgets/image.py
+++ b/mpfmc/widgets/image.py
@@ -7,8 +7,8 @@ class ImageWidget(MpfWidget, Image):
     widget_type_name = 'Image'
     merge_settings = ('height', 'width')
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def __init__(self, mc, config, key=None, **kwargs):
+        super().__init__(mc=mc, config=config, key=key)
 
         try:
             self.image = self.mc.images[self.config['image']]

--- a/mpfmc/widgets/line.py
+++ b/mpfmc/widgets/line.py
@@ -8,8 +8,8 @@ class Line(MpfWidget, Widget):
 
     widget_type_name = 'Line'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def on_pos(self, *args):
+        del args
 
         with self.canvas:
             Color(*self.config['color'])

--- a/mpfmc/widgets/point.py
+++ b/mpfmc/widgets/point.py
@@ -6,12 +6,10 @@ from mpfmc.uix.widget import MpfWidget
 
 class Point(MpfWidget, Widget):
 
-    widget_type_name = 'Line'
+    widget_type_name = 'Point'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        config['pointsize'] = config.pop('size')
-
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def on_pos(self, *args):
+        del args
 
         with self.canvas:
             Color(*self.config['color'])

--- a/mpfmc/widgets/quad.py
+++ b/mpfmc/widgets/quad.py
@@ -8,8 +8,8 @@ class Quad(MpfWidget, Widget):
 
     widget_type_name = 'Quad'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def on_pos(self, *args):
+        del args
 
         with self.canvas:
             Color(*self.config['color'])

--- a/mpfmc/widgets/rectangle.py
+++ b/mpfmc/widgets/rectangle.py
@@ -11,28 +11,29 @@ class Rectangle(MpfWidget, Widget):
 
     widget_type_name = 'Rectangle'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def on_pos(self, *args):
+        del args
 
-        pos = set_position(slide.width,
-                           slide.height,
-                           self.width, self.height,
-                           self.config['x'],
-                           self.config['y'],
-                           self.config['anchor_x'],
-                           self.config['anchor_y'],
-                           self.config['adjust_top'],
-                           self.config['adjust_right'],
-                           self.config['adjust_bottom'],
-                           self.config['adjust_left'])
+        self.pos = set_position(self.parent.width,
+                                self.parent.height,
+                                self.width,
+                                self.height,
+                                self.config['x'],
+                                self.config['y'],
+                                self.config['anchor_x'],
+                                self.config['anchor_y'],
+                                self.config['adjust_top'],
+                                self.config['adjust_right'],
+                                self.config['adjust_bottom'],
+                                self.config['adjust_left'])
 
         with self.canvas:
             Color(*self.config['color'])
 
             if self.config['corner_radius']:
-                RoundedRectangle(pos=pos, size=self.size,
+                RoundedRectangle(pos=self.pos, size=self.size,
                                  radius=(self.config['corner_radius'],
                                          self.config['corner_radius']),
                                  segments=self.config['corner_segments'])
             else:
-                KivyRectangle(pos=pos, size=self.size)
+                KivyRectangle(pos=self.pos, size=self.size)

--- a/mpfmc/widgets/text.py
+++ b/mpfmc/widgets/text.py
@@ -13,8 +13,8 @@ class Text(MpfWidget, Label):
                       'max_lines', 'strip', 'shorten_from', 'split_str',
                       'unicode_errors', 'color')
 
-    def __init__(self, mc, config, slide, key=None, play_kwargs=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def __init__(self, mc, config, key=None, play_kwargs=None, **kwargs):
+        super().__init__(mc=mc, config=config, key=key)
 
         self.original_text = self._get_text_string(config.get('text', ''))
 

--- a/mpfmc/widgets/text_input.py
+++ b/mpfmc/widgets/text_input.py
@@ -15,8 +15,8 @@ from mpfmc.widgets.text import Text
 class MpfTextInput(Text):
     widget_type_name = 'text_input'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def __init__(self, mc, config, key=None, **kwargs):
+        super().__init__(mc=mc, config=config, key=key)
         """
 
         Note that this class is called *MpfTextInput* instead of *TextInput*
@@ -49,7 +49,7 @@ class MpfTextInput(Text):
         del dt
 
         for target in self.mc.targets.values():
-            for w in target.slide_frame_parent.walk():
+            for w in target.parent.walk():
                 try:
                     if w.key == self.config['key']:
                         self.linked_text_widget = w
@@ -227,7 +227,7 @@ class MpfTextInput(Text):
         self._deregister_events()
         self.active = False
         self.text = ''
-        self.slide.remove_widget(self)
+        self.parent.remove_widget(self)
 
     def prepare_for_removal(self):
         self.done()

--- a/mpfmc/widgets/triangle.py
+++ b/mpfmc/widgets/triangle.py
@@ -8,8 +8,8 @@ class Triangle(MpfWidget, Widget):
 
     widget_type_name = 'Triangle'
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def on_pos(self, *args):
+        del args
 
         with self.canvas:
             Color(*self.config['color'])

--- a/mpfmc/widgets/video.py
+++ b/mpfmc/widgets/video.py
@@ -8,8 +8,8 @@ class VideoWidget(MpfWidget, Video):
     widget_type_name = 'Video'
     merge_settings = ('height', 'width')
 
-    def __init__(self, mc, config, slide, key=None, **kwargs):
-        super().__init__(mc=mc, slide=slide, config=config, key=key)
+    def __init__(self, mc, config, key=None, **kwargs):
+        super().__init__(mc=mc, config=config, key=key)
 
         try:
             self.video = self.mc.videos[self.config['video']]


### PR DESCRIPTION
Several changes here:

First, z: values for widgets are now highest to lowest, so z: 2 will be drawn on top of z: 1. Order of widgets in the config file is used for widgets with the same z: value. Widgets higher up the list are drawn on top of widgets lower in the list.

Second, negative z: value are gone. (Will raise a ValueError.) They're replaced by a `target:` setting in the widget_player to select a display target (a display or slide_frame). These can be combined with (positive) z: values to adjust widget order in the display target.

The `target:` setting is not valid in widget or slide configs since the configs are not tied to a display until they're played. This should be fine though, just add `target:` to your widget_player or slide_player instead of your widgets or slides and it's fine.

If you only have one display and don't use slide frames, you can use `target: default` to target the parent frame of your display. (or use whatever name the display is called in the `displays:` section of your config.

At the API level, this required a few changes.

Widgets no longer have a "slide" attribute since widgets attached to a display target don't have a slide. (This affected the MpfWidget base class signature.) Instead, the `parent` attribute can be used in all places where the `slide` attribute was used in the past.

This also required a change to how widget positioning was calculated. Previously it was done in the widget's **init**(), but now widget objects can be created before they're attached to a display target, so the positioning is calculated when the widget is actually attached rather than on init.

Tests have been updated (and several z-order bugs where found) which have been cleaned up.
