### PR TITLE
Bugfix: Do not wait for "None" slide additional 'slide' check

### DIFF
--- a/mpfmc/config_players/widget_player.py
+++ b/mpfmc/config_players/widget_player.py
@@ -30,7 +30,7 @@ class McWidgetPlayer(McConfigPlayer):
     def _get_slide(self, s):
         slide = None
 
-        if s['slide']:
+        if 'slide' in s and s['slide']:
             slide_name = s.pop('slide')
             try:
                 slide = self.machine.active_slides[slide_name]


### PR DESCRIPTION
This PR implements the same change as https://github.com/missionpinball/mpf-mc/commit/cdab4e06f183fae4ae9227d1bfb10144359d5a9b but in another location.

The original fix added a check for `if 'slide' in s and s['slide']` on line 79 of _widget_player.py_, but the same check is needed on line 33.