### PR TITLE
Enable anchor rounding on widgets and displays

### DIFF
--- a/mpfmc/tests/test_Widget.py
+++ b/mpfmc/tests/test_Widget.py
@@ -165,6 +165,68 @@ class TestWidget(MpfMcTestCase):
         widget = Rectangle(self.mc, config)
         self.assertEqual(widget.anchor_offset_pos, (-10, -10))
 
+    def test_on_container_parent(self):
+        parent = self.mc.targets['default'].add_slide(name='parent')
+
+        # test without rounding
+        config = {"anchor_x": "center", "anchor_y": "middle",
+                  "width": 11, "height": 11, "type": "rectangle"}
+        self.mc.config_validator.validate_config('widgets:rectangle', config, base_spec='widgets:common')
+        widget = Rectangle(self.mc, config)
+
+        widget.on_container_parent(None, parent)
+        self.assertEqual(widget.pos, [400, 300])
+
+        # test with offsetting down
+        config = {"anchor_x": "center", "anchor_y": "middle",
+                  "width": 11, "height": 11, "type": "rectangle",
+                  "round_anchor_x": "left", "round_anchor_y": "bottom",}
+        self.mc.config_validator.validate_config('widgets:rectangle', config, base_spec='widgets:common')
+        widget = Rectangle(self.mc, config)
+        widget.on_container_parent(None, parent)
+        self.assertEqual(widget.pos, [399.5, 299.5])
+
+        # test with offsetting up
+        config = {"anchor_x": "center", "anchor_y": "middle",
+                  "width": 11, "height": 11, "type": "rectangle",
+                  "round_anchor_x": "right", "round_anchor_y": "top",}
+        self.mc.config_validator.validate_config('widgets:rectangle', config, base_spec='widgets:common')
+        widget = Rectangle(self.mc, config)
+        widget.on_container_parent(None, parent)
+        self.assertEqual(widget.pos, [400.5, 300.5])
+
+        # test with inheriting parent offsets
+        config = {"anchor_x": "center", "anchor_y": "middle",
+                  "width": 11, "height": 11, "type": "rectangle"}
+        parent.display.config['round_anchor_x'] = "left"
+        parent.display.config['round_anchor_y'] = "top"
+        self.mc.config_validator.validate_config('widgets:rectangle', config, base_spec='widgets:common')
+        widget = Rectangle(self.mc, config)
+        widget.on_container_parent(None, parent)
+        self.assertEqual(widget.pos, [399.5, 300.5])
+
+        # test with widget config overriding parent offset
+        config = {"anchor_x": "center", "anchor_y": "middle",
+                  "width": 11, "height": 11, "type": "rectangle",
+                  "round_anchor_x": "right", "round_anchor_y": "bottom"}
+        parent.display.config['round_anchor_x'] = "left"
+        parent.display.config['round_anchor_y'] = "top"
+        self.mc.config_validator.validate_config('widgets:rectangle', config, base_spec='widgets:common')
+        widget = Rectangle(self.mc, config)
+        widget.on_container_parent(None, parent)
+        self.assertEqual(widget.pos, [400.5, 299.5])
+
+        # test with widget config removing parent offset
+        config = {"anchor_x": "center", "anchor_y": "middle",
+                  "width": 11, "height": 11, "type": "rectangle",
+                  "round_anchor_x": "center", "round_anchor_y": "middle"}
+        parent.display.config['round_anchor_x'] = "left"
+        parent.display.config['round_anchor_y'] = "top"
+        self.mc.config_validator.validate_config('widgets:rectangle', config, base_spec='widgets:common')
+        widget = Rectangle(self.mc, config)
+        widget.on_container_parent(None, parent)
+        self.assertEqual(widget.pos, [400, 300])
+
     def test_calculate_initial_position(self):
         # Parent is
         # 100x100, so center of the parent is 50, 50

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -176,15 +176,40 @@ class Widget(KivyWidget):
                                                        self.config['x'],
                                                        self.config['y'])
 
+            # The top-most parent owns the display, so traverse up to find the config
+            top_widget = parent
+            while top_widget.parent:
+                top_widget = top_widget.parent
+            displayconfig = top_widget.display.config if hasattr(top_widget, 'display') else dict()
+
+            # If the positioning is centered, look for a rounding setting to avoid
+            # fractional anchor positions. Fallback to display's config if available
+            round_anchor_x = self.config['anchor_x'] in ('center', 'middle') and (self.config['round_anchor_x'] or displayconfig.get('round_anchor_x'))
+            round_anchor_y = self.config['anchor_y'] in ('center', 'middle') and (self.config['round_anchor_y'] or displayconfig.get('round_anchor_y'))
+            offset_x = 0
+            offset_y = 0
+
+            if round_anchor_x == 'left':
+                offset_x = self.anchor_offset_pos[0] % -1
+            elif round_anchor_x == 'right':
+                offset_x = self.anchor_offset_pos[0] % 1
+            if round_anchor_y == 'top':
+                offset_y = self.anchor_offset_pos[1] % 1
+            elif round_anchor_y == 'bottom':
+                offset_y = self.anchor_offset_pos[1] % -1
+
+            self.pos[0] += offset_x
+            self.pos[1] += offset_y
+
     # pylint: disable-msg=too-many-arguments
     # pylint: disable-msg=too-many-statements
     @staticmethod
     def calculate_initial_position(parent_w: int, parent_h: int,
                                    x: Optional[Union[int, str]] = None,
                                    y: Optional[Union[int, str]] = None) -> tuple:
-        """Returns the initial x,y position for the widget within a larger 
+        """Returns the initial x,y position for the widget within a larger
         parent frame based on several positioning parameters. This position will
-        be combined with the widget anchor position to determine its actual 
+        be combined with the widget anchor position to determine its actual
         position on the screen.
 
         Args:


### PR DESCRIPTION
This PR enables a new setting to prevent MPF-MC from anchoring center-aligned widgets on partial pixels. This is ideal for low-resolution displays like DMDs where fractional positioning creates undesirable blur.

By specifying `round_anchor_x` and/or `round_anchor_y`, a user can force MPF-MC to position widgets on whole pixel coordinates only.

Accompanying PRs for **mpf** and **mpf-docs**:
* https://github.com/missionpinball/mpf/pull/1065
* https://github.com/missionpinball/mpf-docs/pull/127

Feedback and suggestions appreciated!