### PR TITLE
Anchor rounding for dynamic text and percentage positions

### DIFF
--- a/mpfmc/tests/test_Text.py
+++ b/mpfmc/tests/test_Text.py
@@ -182,6 +182,57 @@ class TestText(MpfMcTestCase):
         self.advance_time()
         self.assertEqual(self.get_widget().text, 'Player 2 test variable')
 
+    def test_position_rounding(self):
+        # staight var, no player specified
+        self.mc.game_start()
+        self.advance_time()
+        self.mc.add_player(1)
+        self.advance_time()
+        self.mc.player_start_turn(1)
+        self.advance_time()
+
+        self.assertTrue(self.mc.player)
+
+        # set var, should update widget with even pixel width and not offset
+        self.mc.player.test_var = 'its even'
+        self.mc.events.post('text_with_player_var1')
+        self.advance_time()
+
+        self.get_widget()._round_anchor_styles = ('left', None)
+
+        bounding_box = self.get_widget().canvas.children[-1]
+        self.assertEqual(self.get_widget().text, 'its even')
+        self.assertEqual(bounding_box.size, (343, 118))
+        self.assertEqual(bounding_box.pos, (200, 150))
+
+        # update var, should update widget with an odd pixel width and offset DOWN
+        self.mc.player.test_var = 'odd'
+        self.advance_time()
+
+        bounding_box = self.get_widget().canvas.children[-1]
+        self.assertEqual(self.get_widget().text, 'odd')
+        self.assertEqual(bounding_box.size, (169, 118))
+        self.assertEqual(bounding_box.pos, (199.5, 150))
+
+        # update var, should update widget with an odd pixel width and offset UP
+        self.get_widget()._round_anchor_styles = ('right', None)
+        self.mc.player.test_var = 'also odd'
+        self.advance_time()
+
+        bounding_box = self.get_widget().canvas.children[-1]
+        self.assertEqual(self.get_widget().text, 'also odd')
+        self.assertEqual(bounding_box.size, (381, 118))
+        self.assertEqual(bounding_box.pos, (200.5, 150))
+
+        # update var, should update widget with an even pixel width and not offset
+        self.mc.player.test_var = 'no round'
+        self.advance_time()
+
+        bounding_box = self.get_widget().canvas.children[-1]
+        self.assertEqual(self.get_widget().text, 'no round')
+        self.assertEqual(bounding_box.size, (394, 118))
+        self.assertEqual(bounding_box.pos, (200, 150))
+
     def test_current_player(self):
         # verifies that current player text update when current player changes
         self.mc.game_start()

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional, List, Tuple
 from copy import deepcopy
 from functools import reduce
+import math
 
 from kivy.clock import Clock
 from kivy.animation import Animation
@@ -173,11 +174,6 @@ class Widget(KivyWidget):
                                             opacity=1,
                                             line_height=1)
 
-            self.pos = self.calculate_initial_position(parent.width,
-                                                       parent.height,
-                                                       self.config['x'],
-                                                       self.config['y'])
-
             # The top-most parent owns the display, so traverse up to find the config
             top_widget = parent
             while hasattr(top_widget, 'parent') and not hasattr(top_widget, 'display'):
@@ -186,13 +182,19 @@ class Widget(KivyWidget):
 
             # If the positioning is centered, look for a rounding setting to avoid
             # fractional anchor positions. Fallback to display's config if available
-            round_anchor_x = self.config['anchor_x'] in ('center', 'middle') and (
-                self.config['round_anchor_x'] or displayconfig.get('round_anchor_x'))
-            round_anchor_y = self.config['anchor_y'] in ('center', 'middle') and (
-                self.config['round_anchor_y'] or displayconfig.get('round_anchor_y'))
+            round_anchor_x = self.config['round_anchor_x'] or displayconfig.get('round_anchor_x')
+            round_anchor_y = self.config['round_anchor_y'] or displayconfig.get('round_anchor_y')
 
             # Store the anchor rounding config from widget/display to avoid recalculation
             self._round_anchor_styles = (round_anchor_x, round_anchor_y)
+
+            self.pos = self.calculate_initial_position(parent.width,
+                                                       parent.height,
+                                                       self.config['x'],
+                                                       self.config['y'],
+                                                       round_anchor_x,
+                                                       round_anchor_y)
+
             # Update the initial widget position based on the rounding config
             self.pos = self.calculate_rounded_position(self.anchor_offset_pos)
 
@@ -221,7 +223,9 @@ class Widget(KivyWidget):
     @staticmethod
     def calculate_initial_position(parent_w: int, parent_h: int,
                                    x: Optional[Union[int, str]] = None,
-                                   y: Optional[Union[int, str]] = None) -> tuple:
+                                   y: Optional[Union[int, str]] = None,
+                                   round_x: Optional[Union[bool, str]] = None,
+                                   round_y: Optional[Union[bool,str]] = None) -> tuple:
         """Returns the initial x,y position for the widget within a larger
         parent frame based on several positioning parameters. This position will
         be combined with the widget anchor position to determine its actual
@@ -250,6 +254,14 @@ class Widget(KivyWidget):
                 return the vertical center (parent height / 2). Can also start
                 with the strings "top", "middle", or "bottom" which can be combined
                 with values. (e.g top-2, bottom+4, middle-1)
+            round_x: (Optional) Specifies a direction of either "left" or "right"
+                to round the calculated pixel value for the horizontal position.
+                Used to prevent partial pixel placement on DMDs, especially when
+                position/anchors are specified in percentages
+            round_y: (Optional) Specifies a direction of either "bottom" or "top"
+                to round the calculated pixel value for the vertical position.
+                Used to prevent partial pixel placement on DMDs, especially when
+                position/anchors are specified in percentages
 
         Returns: Tuple of x, y coordinates for the lower-left corner of the
             widget you're placing.
@@ -294,6 +306,11 @@ class Widget(KivyWidget):
             x = percent_to_float(x, parent_w)
             x += start_x
 
+            if round_x == 'left':
+                x = math.floor(x)
+            elif round_x == 'right':
+                x = math.ceil(x)
+
         # --------------------
         # Y / height / vertical
         # --------------------
@@ -324,6 +341,11 @@ class Widget(KivyWidget):
 
             y = percent_to_float(y, parent_h)
             y += start_y
+
+            if round_y == 'bottom':
+                y = math.floor(y)
+            elif round_y == 'top':
+                y = math.ceil(y)
 
         return x, y
 

--- a/mpfmc/widgets/text.py
+++ b/mpfmc/widgets/text.py
@@ -93,16 +93,20 @@ class Text(Widget):
     def _draw_widget(self, *args):
         """Draws the image (draws a rectangle using the image texture)"""
         del args
-
-        anchor = (self.x - self.anchor_offset_pos[0], self.y - self.anchor_offset_pos[1])
         self.canvas.clear()
+
+        # Redrawing the widget doesn't reposition, so update manually
+        anchor = (self.x - self.anchor_offset_pos[0], self.y - self.anchor_offset_pos[1])
+        # Save the updated position as a new variable, such that consecutive text
+        # changes don't introduce gradual shifts in position.
+        pos = super(Text, self).calculate_rounded_position(anchor)
 
         if len(self._label.text) > 0:
             with self.canvas:
                 Color(*self.color)
                 Rotate(angle=self.rotation, origin=anchor)
                 Scale(self.scale).origin = anchor
-                Rectangle(pos=self.pos, size=self.size, texture=self._label.texture)
+                Rectangle(pos=pos, size=self.size, texture=self._label.texture)
 
     def on_label_texture(self, instance, texture):
         del instance


### PR DESCRIPTION
This PR extends/improves the work of PR #294 with the following changes:

- Text widgets will re-calculate rounding when placeholder text value changes
- Rounding now works on percentage-based positions (e.g. ``y: top-8%``)
- Rounding now works on any anchor alignment, not just ``center``/``middle``

This should conclude all rounding-related work!