### PR TITLE
Enable ‘casing’ config setting for Text Widgets

### DIFF
--- a/mpfmc/tests/machine_files/text/config/test_text.yaml
+++ b/mpfmc/tests/machine_files/text/config/test_text.yaml
@@ -150,6 +150,41 @@ slides:
       text: TEST NUMBER GROUPING & DOUBLE ZEROS
       y: 200
 
+  text_nocase:
+    - type: text
+      text: sAmPlE tExT caSiNg
+    - type: text
+      text: TEST CASING none
+      y: 200
+  text_lower:
+    - type: text
+      text: sAmPlE tExT caSiNg
+      casing: lower
+    - type: text
+      text: TEST CASING lower
+      y: 200
+  text_upper:
+    - type: text
+      text: sAmPlE tExT caSiNg
+      casing: upper
+    - type: text
+      text: TEST CASING upper
+      y: 200
+  text_title:
+    - type: text
+      text: sAmPlE tExT caSiNg
+      casing: title
+    - type: text
+      text: TEST CASING title
+      y: 200
+  text_capitalize:
+    - type: text
+      text: sAmPlE tExT caSiNg
+      casing: capitalize
+    - type: text
+      text: TEST CASING capitalize
+      y: 200
+
   mpfmc_font:
     - type: text
       text: MPF-MC FONT TEST
@@ -200,6 +235,11 @@ slide_player:
   text_with_player_var4: text_with_player_var4
   text_with_player_var_and_event: text_with_player_var_and_event
   number_grouping: number_grouping
+  text_nocase: text_nocase
+  text_lower: text_lower
+  text_upper: text_upper
+  text_title: text_title
+  text_capitalize: text_capitalize
   text_string1: text_string1
   text_string2: text_string2
   text_string3: text_string3

--- a/mpfmc/tests/test_Text.py
+++ b/mpfmc/tests/test_Text.py
@@ -340,6 +340,27 @@ class TestText(MpfMcTestCase):
         self.get_widget().update_text('2000000')
         self.assertEqual(self.get_widget().text, '2,000,000')
         self.advance_time()
+        
+    def test_text_casing(self):
+        self.mc.events.post('text_nocase')
+        self.advance_time()
+        self.assertEqual(self.get_widget().text, 'sAmPlE tExT caSiNg')
+        
+        self.mc.events.post('text_lower')
+        self.advance_time()
+        self.assertEqual(self.get_widget().text, 'sample text casing')
+
+        self.mc.events.post('text_upper')
+        self.advance_time()
+        self.assertEqual(self.get_widget().text, 'SAMPLE TEXT CASING')
+        
+        self.mc.events.post('text_title')
+        self.advance_time()
+        self.assertEqual(self.get_widget().text, 'Sample Text Casing')
+        
+        self.mc.events.post('text_capitalize')
+        self.advance_time()
+        self.assertEqual(self.get_widget().text, 'Sample text casing')
 
     def test_text_string1(self):
         # simple text string in machine config

--- a/mpfmc/widgets/text.py
+++ b/mpfmc/widgets/text.py
@@ -52,7 +52,7 @@ class Text(Widget):
                       'valign', 'padding_x', 'padding_y', 'text_size',
                       'shorten', 'mipmap', 'markup', 'line_height',
                       'max_lines', 'strip', 'shorten_from', 'split_str',
-                      'unicode_errors', 'color')
+                      'unicode_errors', 'color', 'casing')
     animation_properties = ('x', 'y', 'font_size', 'color', 'opacity', 'rotation', 'scale')
 
     def __init__(self, mc: "MpfMc", config: dict, key: Optional[str]=None,
@@ -208,6 +208,10 @@ class Text(Widget):
                 for item in number_list:
                     grouped_item = Text.group_digits(item)
                     text = text.replace(str(item), grouped_item)
+
+            if self.config['casing'] in ('lower', 'upper', 'title', 'capitalize'):
+                text = getattr(text, self.config['casing'])()
+
         self._label.text = text
         self._label.texture_update()
 


### PR DESCRIPTION
This PR adds a new configuration setting for `text`-type widgets that allows per-widget case styling. The valid options are "lower", "upper", "title", and "capitalize", and leverage Python's native string methods by the same names.

This setting is ideal for using string-type player variables on slides while maintaining both the variable casing convention (all lowercase snake_case) and "pretty" slide text.

Corresponding updates to MPF `config_spec.py` and MPF Docs will get PRs if this change is approved.