### PR TITLE
Support conditional event handlers on slide player

### DIFF
--- a/mpfmc/config_players/slide_player.py
+++ b/mpfmc/config_players/slide_player.py
@@ -137,6 +137,12 @@ class McSlidePlayer(McConfigPlayer):
             settings = settings['slides']
 
         for slide, s in settings.items():
+            slide_dict = self.machine.placeholder_manager.parse_conditional_template(slide)
+
+            if slide_dict["condition"] and not slide_dict["condition"].evaluate(kwargs):
+                continue
+            slide = slide_dict["name"]
+
             s.update(kwargs)
 
             if s["slide"]:


### PR DESCRIPTION
In my never-ending quest to swap conditional events for conditional event handlers, here's a PR that extends conditional handlers to `slide_player`.

With this change, fun things like this are possible:

```
slide_player:
  recruit_advance{status==1}:
    recruiting_advance_slide_2:
      expire: 1s
  recruit_advance{status==2}:
    recruiting_advance_slide_1:
      expire: 1s
  recruit_advance{status==3}:
    recruiting_advance_slide_lit:
      expire: 2s
  missionselect_pass_highlighted:
    missionselect_intro_slide{current_player.missionselect_init==0}:
      action: play
    missionselect_pass_slide{current_player.missionselect_init!=0}:
      action: play
```

