### PR TITLE
Bug fix variable name error in sound player

### DIFF
--- a/mpfmc/config_players/sound_player.py
+++ b/mpfmc/config_players/sound_player.py
@@ -107,7 +107,7 @@ Here are several various examples:
                 self.machine.log.error("SoundPlayer: The specified track ('{}') "
                                        "does not exist. Unable to perform '{}' action "
                                        "on sound '{}'."
-                                       .format(s['track'], s['action'], sound_name))
+                                       .format(s['track'], action, sound_name))
                 return
 
             # Determine action to perform


### PR DESCRIPTION
This PR fixes a minor error in sound_player.

There is an error log event when a sound is encountered without a valid "track" value. The error log intends to include the sound's "action" attribute in the log output, but 8 lines earlier the action value was moved from an attribute to a variable:
```
action = s['action'].lower()
del s[action']
```

As a result, encountering the error log causes a `KeyError` that crashes MPF-MC.

This PR fixes the log output to reference `action` instead of `s['action']`.