### PR TITLE
Add support for ‘—no-sound’ command line arg to disable sound system

### DIFF
--- a/mpfmc/commands/mc.py
+++ b/mpfmc/commands/mc.py
@@ -139,6 +139,9 @@ class Command(object):
                             action="store_const", dest="force_platform",
                             const='smart_virtual', help=argparse.SUPPRESS)
 
+        parser.add_argument("--no-sound",
+                            action="store_true", dest="no_sound", default=False)
+
         args = parser.parse_args(args)
 
         args.configfile = Util.string_to_list(args.configfile)

--- a/mpfmc/core/mc.py
+++ b/mpfmc/core/mc.py
@@ -151,7 +151,7 @@ class MpfMc(App):
 
         # Initialize the sound system (must be done prior to creating the AssetManager).
         # If the sound system is not available, do not load any other sound-related modules.
-        if SoundSystem is None or self.options["no_sound"]:
+        if SoundSystem is None or self.options.get("no_sound"):
             self.sound_system = None
         else:
             self.sound_system = SoundSystem(self)

--- a/mpfmc/core/mc.py
+++ b/mpfmc/core/mc.py
@@ -151,7 +151,7 @@ class MpfMc(App):
 
         # Initialize the sound system (must be done prior to creating the AssetManager).
         # If the sound system is not available, do not load any other sound-related modules.
-        if SoundSystem is None:
+        if SoundSystem is None or self.options["no_sound"]:
             self.sound_system = None
         else:
             self.sound_system = SoundSystem(self)

--- a/mpfmc/tests/MpfMcTestCase.py
+++ b/mpfmc/tests/MpfMcTestCase.py
@@ -48,6 +48,7 @@ class MpfMcTestCase(unittest.TestCase):
                     configfile=Util.string_to_list(self.get_config_file()),
                     no_load_cache=False,
                     create_config_cache=True,
+                    no_sound=False,
                     bcp=False)
 
     def getAbsoluteMachinePath(self):


### PR DESCRIPTION
I've been thinking about how we share examples and help solve problems by running sample code (and each other's game code), which is easy to procure and share over github. Unfortunately github repos don't always include all the sound file binaries of an MPF game, so it's impossible to clone and run a game without also procuring its sound files and copying them to the appropriate mode folders.

This PR offers a workaround by allowing the command line to disable the MPF-MC sound system, which prevents checking for sound asset files and allows games to run with missing files. 

There is a corresponding PR for this command line arg in MPF, which I'll put up if this idea is approved.