### PR TITLE
#341 Prevent duplicate text widget handlers

### DIFF
--- a/mpfmc/widgets/text.py
+++ b/mpfmc/widgets/text.py
@@ -255,12 +255,12 @@ class Text(Widget):
                     self.add_machine_var_handler(name=variable_name)
 
     def add_player_var_handler(self, name: str) -> None:
-        self.mc.events.add_handler('player_{}'.format(name),
-                                   self._player_var_change)
+        self.mc.events.replace_handler('player_{}'.format(name),
+                                       self._player_var_change)
 
     def add_current_player_handler(self) -> None:
-        self.mc.events.add_handler('player_turn_start',
-                                   self._player_var_change)
+        self.mc.events.replace_handler('player_turn_start',
+                                       self._player_var_change)
 
     def add_machine_var_handler(self, name: str) -> None:
         self.mc.events.add_handler('machine_var_{}'.format(name),


### PR DESCRIPTION
This fix addresses issue #341 where text widgets get multiple handlers. This change swaps `events.add_handler()` with `events.replace_handler()` to prevent the same handler from being added multiple times, no matter how frequently the method is called.