### PR TITLE
Fix kivy deprecation warning on Scale().scale property

### DIFF
--- a/mpfmc/widgets/text.py
+++ b/mpfmc/widgets/text.py
@@ -147,7 +147,9 @@ class Text(Widget):
             self.rotate.origin = anchor
             self.rotate.angle = self.rotation
         if self.scale_instruction:
-            self.scale_instruction.scale = self.scale
+            self.scale_instruction.x = self.scale # Kivy 1.6.0 requires explicit per-axis scale args
+            self.scale_instruction.y = self.scale
+            self.scale_instruction.z = self.scale
             self.scale_instruction.origin = anchor
         if self.rectangle:
             self.rectangle.pos = pos


### PR DESCRIPTION
Kivy 1.6.0 deprecated the `scale` property of `graphics.Scale` objects, which triggers a log warning when MPF renders a text widget.

This PR changes the text widget syntax to explicitly assign the x,y,z scale values according to the desired scale factor. 

The `x`, `y`, and `z` properties of `graphics.Scale` have existing as long as `scale` has, so there is little risk of backwards-breaking changes.