### PR TITLE
Support multiple (stacked) style values for widgets

### DIFF
--- a/mpfmc/tests/machine_files/display/config/test_display.yaml
+++ b/mpfmc/tests/machine_files/display/config/test_display.yaml
@@ -23,18 +23,6 @@ widget_styles:
     font_size: 10
     adjust_top: 2
     adjust_bottom: 3
-  space title huge:
-    font_name: DEADJIM
-    font_size: 29
-    antialias: true
-    adjust_top: 3
-    adjust_bottom: 3
-  space title:
-    font_name: DEADJIM
-    font_size: 21
-    antialias: true
-    adjust_top: 2
-    adjust_bottom: 3
   medium:
     font_name: pixelmix
     font_size: 8
@@ -45,7 +33,7 @@ widget_styles:
     font_size: 9
     adjust_top: 2
     adjust_bottom: 3
-  tall title:
+  tall_title:
     font_name: big_noodle_titling
     font_size: 20
 
@@ -60,7 +48,7 @@ slides:
         dot_color: ff5500
         background_color: 220000
   - type: text
-    style: tall title
+    style: tall_title
     text: MISSION PINBALL FRAMEWORK
     anchor_y: top
     y: top-2
@@ -71,7 +59,7 @@ slides:
     height: 130
     color: 444444
   - type: text
-    style: tall title
+    style: tall_title
     text: DEMO MAN
     anchor_x: right
     anchor_y: bottom

--- a/mpfmc/tests/machine_files/widget_styles/config/test_widget_styles.yaml
+++ b/mpfmc/tests/machine_files/widget_styles/config/test_widget_styles.yaml
@@ -15,6 +15,8 @@ widget_styles:
   bigStyle:
     font_size: 100
     halign: left
+  stackedStyle:
+    color: blue
 
 slides:
   slide1:
@@ -38,9 +40,21 @@ slides:
       text: HELLO
       style: bigStyle
       font_size: 50
+  slide6:
+    - type: text
+      text: HELLO TOO
+      style: bigStyle stackedStyle
+  slide7:
+    - type: text
+      text: HELLO THREE
+      style:
+        - text_default
+        - stackedStyle
 
 slide_player:
   slide1: slide1
   slide3: slide3
   slide4: slide4
   slide5: slide5
+  slide6: slide6
+  slide7: slide7

--- a/mpfmc/tests/test_WidgetStyles.py
+++ b/mpfmc/tests/test_WidgetStyles.py
@@ -49,6 +49,18 @@ class TestWidgetStyles(MpfMcTestCase):
 
         self.assertEqual(self.get_widget().font_size, 50)
 
+    def test_stacked_styles(self):
+        self.mc.events.post('slide6')
+        self.advance_time()
+        self.assertEqual(self.get_widget().font_size, 100)
+        self.assertEqual(self.get_widget().color, [0.0, 0.0, 1.0, 1]);
+
+    def test_stacked_order_overrides(self):
+        self.mc.events.post('slide7')
+        self.advance_time()
+        self.assertEqual(self.get_widget().font_size, 21)
+        self.assertEqual(self.get_widget().color, [0.0, 0.0, 1.0, 1]);
+
     # todo some future release
 
     # def test_mode_style(self):


### PR DESCRIPTION
This PR changes the behavior for a Widget's `styles:` config setting to support a list of style names instead of a single value. When multiple styles are specified, they will be applied to the widget in sequential order.

The goal is to allow designers to separate the style rules and combine at will, for example creating a set of styles for font sizes/colors and a different set of styles for positioning/alignment. Instead of creating all possible combinations of size/color/position/alignment, individual widgets can reference the various styles they want to include.

This is a breaking change for widget styles that have spaces in their names. I feel this is an acceptable consequence, as we are generally moving away from supporting spaces (names, events, etc). This PR includes a special error handler to predict whether an "Invalid Key" error is triggered by a space-named style and inform the designer about the breaking change.

The MPF config spec companion change is here: https://github.com/missionpinball/mpf/pull/1228