### PR TITLE
Allow style "z" values to define widget layer position

### DIFF
--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -82,13 +82,6 @@ class Widget(KivyWidget):
         self.mc = mc
         self.mc.track_leak_reference(self)
 
-        # Create a container widget as this widget's parent.  The container will adjust
-        # the coordinate system for this widget so that all positional properties are
-        # based on the widget's anchor rather than the lower left corner.
-        self._container = WidgetContainer(self, z=self.config['z'])
-        self._container.add_widget(self)
-        self._container.fbind('parent', self.on_container_parent)
-
         self.animation = None
         self._animation_event_keys = set()
         # MPF event keys for event handlers that have been registered for
@@ -106,6 +99,13 @@ class Widget(KivyWidget):
         self._default_style = None
         self._set_default_style()
         self._apply_style()
+
+        # Create a container widget as this widget's parent.  The container will adjust
+        # the coordinate system for this widget so that all positional properties are
+        # based on the widget's anchor rather than the lower left corner.
+        self._container = WidgetContainer(self, z=self.config['z'])
+        self._container.add_widget(self)
+        self._container.fbind('parent', self.on_container_parent)
 
         if 'color' in self.config and not isinstance(self.config['color'], RGBAColor):
             self.config['color'] = RGBAColor(self.config['color'])


### PR DESCRIPTION
This PR tweaks the initialization order of widgets to build the parent `WidgetContainer` _after_ the widget's styles are processed.

In the current behavior, the container receives a `z` coordinate value based on the widget's own `self.z` property. This means that `z` values can only be specified directly on the widget.

With the change in this PR, the widget's `style:` property is evaluated and applied, including any `z` values defined in its styles. _Then_ the parent container is created, allowing the container to receive a `z` value the widget inherited from a style. 