### PR TITLE
First draft of reusing widgets by name

### DIFF
--- a/mpfmc/config_collections/widget.py
+++ b/mpfmc/config_collections/widget.py
@@ -38,6 +38,12 @@ class WidgetCollection(ConfigCollection):
         return widget_list
 
     def process_widget(self, config: dict) -> dict:
+        if config.get('widget'):
+            try:
+                widget = self.mc.widgets[config.get('widget')]
+                return config
+            except KeyError:
+                raise ValueError('"{}" is not a valid widget name.'.format(config.get('widget')))
         # config is localized widget settings
         try:
             widget_cls = WidgetCollection.type_map[config['type']]

--- a/mpfmc/config_collections/widget.py
+++ b/mpfmc/config_collections/widget.py
@@ -40,17 +40,17 @@ class WidgetCollection(ConfigCollection):
 
     def _load_widget_by_name(self, config) -> dict:
         # Replace placeholders
-        if "(" in config['name'] and ")" in config['name']:
+        if "(" in config['widget'] and ")" in config['widget']:
             config = dict(config)
-            config["widget"] = TextTemplate(self.machine, config['name'].replace("(", "{").replace(")", "}"))
+            config["widget"] = TextTemplate(self.machine, config['widget'].replace("(", "{").replace(")", "}"))
 
-        if config['name'] not in self.mc.widgets:
-            raise ValueError('"{}" is not a valid widget name.'.format(config['name']))
+        elif config['widget'] not in self.mc.widgets:
+            raise ValueError('"{}" is not a valid widget name.'.format(config['widget']))
 
         return config
 
     def process_widget(self, config: dict) -> dict:
-        if "name" in config:
+        if config.get("widget"):
             return self._load_widget_by_name(config)
 
         # config is localized widget settings

--- a/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
+++ b/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
@@ -247,6 +247,15 @@ widgets:
             value: 0.75
             duration: 1s
             easing: out_quint
+  widget_reusable:
+    - type: text
+      text: Reusable Widget
+  widget_placeholder_value1:
+    - type: text
+      text: Value One
+  widget_placeholder_value2:
+    - type: text
+      text: Value Two
 
 widget_player:
   add_widget1_to_current: widget1

--- a/mpfmc/tests/machine_files/widgets/modes/mode1/config/mode1.yaml
+++ b/mpfmc/tests/machine_files/widgets/modes/mode1/config/mode1.yaml
@@ -18,3 +18,19 @@ widget_player:
       key: newton_crosby
       widget_settings:
         text: UPDATED TEXT
+  show_widget_with_placeholder: widget_with_placeholder
+
+widgets:
+  widget_with_placeholder:
+    - type: text
+      text: Placeholder widget
+    - widget: widget_placeholder_(value)
+
+slide_player:
+  show_slide_with_named_widget: slide_with_named_widget
+
+slides:
+  slide_with_named_widget:
+    - type: text
+      text: One Use Widget
+    - widget: widget_reusable

--- a/mpfmc/tests/test_SlidePlayer.py
+++ b/mpfmc/tests/test_SlidePlayer.py
@@ -133,6 +133,8 @@ class TestSlidePlayer(MpfMcTestCase):
         self.assertEqual(len(self.mc.targets['display1'].slides),
                          num_slides - 1)
 
+        self.advance_time(.1)
+
         gc.collect()
         self.assertFalse(slide())
 

--- a/mpfmc/tests/test_Widget.py
+++ b/mpfmc/tests/test_Widget.py
@@ -324,6 +324,38 @@ class TestWidget(MpfMcTestCase):
         # List with multiple items and custom z orders
         self.assertIn('widget4', self.mc.widgets)
 
+    def test_widget_reused_by_name(self):
+        self.assertIn('widget_reusable', self.mc.widgets)
+
+        # Named widgets can only be used in modes
+        self.mc.modes['mode1'].start()
+        self.mc.events.post('show_slide_with_named_widget')
+        self.advance_time()
+        current_slide = self.mc.targets['default'].current_slide
+
+        self.assertEqual(self.mc.targets['default'].current_slide.name, 'slide_with_named_widget')
+        self.assertIn("One Use Widget", [x.widget.text for x in current_slide.widgets])
+        self.assertIn("Reusable Widget", [x.widget.text for x in current_slide.widgets])
+
+    def test_widget_with_placeholder(self):
+        self.assertIn('widget_placeholder_value1', self.mc.widgets)
+        self.assertIn('widget_placeholder_value2', self.mc.widgets)
+        self.mc.targets['default'].add_slide(name='blank_slide_one')
+        self.mc.targets['default'].add_slide(name='blank_slide_two')
+        self.mc.modes['mode1'].start()
+
+        self.mc.targets['default'].show_slide('blank_slide_one')
+        self.mc.events.post('show_widget_with_placeholder', value="value1")
+        self.advance_time()
+        self.assertEqual(["Placeholder widget", "Value One"],
+                         [x.widget.text for x in self.mc.targets['default'].current_slide.widgets])
+
+        self.mc.targets['default'].show_slide('blank_slide_two')
+        self.mc.events.post('show_widget_with_placeholder', value="value2")
+        self.advance_time()
+        self.assertEqual(["Placeholder widget", "Value Two"],
+                         [x.widget.text for x in self.mc.targets['default'].current_slide.widgets])
+
     def test_widget_z_order_from_named_widget(self):
         self.mc.targets['default'].add_slide(name='slide1')
         self.mc.targets['default'].show_slide('slide1')

--- a/mpfmc/uix/display.py
+++ b/mpfmc/uix/display.py
@@ -470,6 +470,8 @@ class Display(ScreenManager):
                     self.current_slide.transition_out)
             else:
                 self.transition = NoTransition()
+
+            self.transition.bind(on_complete=self._remove_transition)
         else:
             new_slide = None
 
@@ -482,6 +484,11 @@ class Display(ScreenManager):
             return False
 
         return True
+
+    def _remove_transition(self, transition):
+        """Remove transition if done."""
+        if self.transition == transition:
+            self.transition = NoTransition()
 
     def _set_current_slide(self, slide: "Slide"):
         # slide frame requires at least one slide, so if you try to set current

--- a/mpfmc/uix/display.py
+++ b/mpfmc/uix/display.py
@@ -473,13 +473,13 @@ class Display(ScreenManager):
         else:
             new_slide = None
 
+        # Set the new slide first, so we can transition out of the old before removing
+        if new_slide:
+            self._set_current_slide(new_slide)
         try:
             self.remove_widget(slide)
         except ScreenManagerException:
             return False
-        finally:
-            if new_slide:
-                self._set_current_slide(new_slide)
 
         return True
 

--- a/mpfmc/uix/slide.py
+++ b/mpfmc/uix/slide.py
@@ -129,69 +129,13 @@ class Slide(Screen, StencilView):
         if name not in self.mc.widgets:
             raise ValueError("Widget {} not found".format(name))
 
-        return self.add_widgets_from_config(config=self.mc.widgets[name],
+        widgets_added = create_widget_objects_from_config(config=self.mc.widgets[name],
+                                            mc=self.mc,
                                             key=key,
                                             widget_settings=widget_settings,
                                             play_kwargs=play_kwargs)
-
-    def add_widgets_from_config(self, config: dict, key: Optional[str] = None,
-                                widget_settings: Optional[dict] = None,
-                                play_kwargs: Optional[dict] = None) -> List["Widget"]:
-        """Add one or more widgets to the slide from a config dictionary.
-
-        Args:
-            config: The configuration dictionary for the widgets to be added.
-            key: An optional key.
-            widget_settings: An optional dictionary of widget settings to override those in
-                the config.
-            play_kwargs: An optional dictionary of play settings to override those in
-                the config.
-
-        Returns:
-            A list of widgets (MpfWidget objects) added to the slide.
-        """
-
-        if not isinstance(config, list):
-            config = [config]
-        widgets_added = list()
-
-        if not play_kwargs:
-            play_kwargs = dict()  # todo
-
-        for widget in config:
-            if widget_settings:
-                widget_settings = self.mc.config_validator.validate_config(
-                    'widgets:{}'.format(widget['type']), widget_settings,
-                    base_spec='widgets:common', add_missing_keys=False)
-
-                widget.update(widget_settings)
-
-            configured_key = widget.get('key', None)
-
-            if (configured_key and key and "." not in key and
-                    configured_key != key):
-                raise KeyError("Widget has incoming key '{}' which does not "
-                               "match the key in the widget's config "
-                               "'{}'.".format(key, configured_key))
-
-            if configured_key:
-                this_key = configured_key
-            else:
-                this_key = key
-
-            # Create the new widget
-            widget_obj = self.mc.widgets.type_map[widget['type']](
-                mc=self.mc, config=widget, slide=self, key=this_key, play_kwargs=play_kwargs)
-
-            top_widget = widget_obj
-
-            # some widgets (like slide frames) have parents, so we need to make
-            # sure that we add the parent widget to the slide
-            while top_widget.parent:
-                top_widget = top_widget.parent
-
-            self.add_widget(top_widget)
-            widgets_added.append(widget_obj)
+        for widget in widgets_added:
+            self.add_widget(widget)
 
         return widgets_added
 

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -844,11 +844,13 @@ def create_widget_objects_from_config(mc: "MpfMc", config: Union[dict, list],
     Creates one or more widgets from config settings.
 
     Args:
-        mc:
-        config:
-        key:
-        play_kwargs:
-        widget_settings:
+        mc: An instance of MC
+        config: The configuration dictionary for the widgets to be created.
+        key: An optional key.
+        play_kwargs: An optional dictionary of play settings to override those in
+            the config.
+        widget_settings: An optional dictionary of widget settings to override those in
+            the config.
 
     Returns:
         A list of the WidgetContainer objects created.
@@ -861,6 +863,14 @@ def create_widget_objects_from_config(mc: "MpfMc", config: Union[dict, list],
         play_kwargs = dict()  # todo
 
     for widget in config:
+        # Lookup a pre-defined widget based on a name
+        name = widget.get('widget', None)
+        if name:
+            widgets_added += create_widget_objects_from_library(name=name,
+                                                                mc=mc,
+                                                                play_kwargs=play_kwargs,
+                                                                widget_settings=widget_settings)
+            continue
         if widget_settings:
             widget_settings = mc.config_validator.validate_config(
                 'widgets:{}'.format(widget['type']), widget_settings,

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -924,6 +924,11 @@ def create_widget_objects_from_library(mc: "MpfMc", name: str,
         A list of the MpfWidget objects created.
     """
     del kwargs
+
+    # If the name is a placeholder template, evaluate it against the args
+    if name and hasattr(name, "evaluate"):
+        name = name.evaluate(play_kwargs)
+
     if name not in mc.widgets:
         raise ValueError("Widget {} not found".format(name))
 

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -1,3 +1,4 @@
+# pylint: disable-msg=too-many-lines
 """A widget on a slide."""
 from typing import Union, Optional, List, Tuple
 from copy import deepcopy


### PR DESCRIPTION
This PR demonstrates a new way to implement widgets on slides and reduce code duplication. If this functionality already exists, please let me know so I can improve the documentation!

I've added a new setting for a slide's `widgets:` list that allows a slide to reference a widget defined elsewhere, just like `widget_player` does.

```
widgets:
  default_background:
    - type: image
      image: background_pattern

slides:
  intro_slide:
    widgets:
      - type: text
        text: Welcome!
      - widget: default_background
```

The code is very simple and just touches _config_collections/widget.py_ and _uix/widget.py_. If a `widget:` value is set, the parent widget fetches the referenced name and appends the resulting widget(s) to itself.

In working on this, I discovered a large duplication of widget parsing/styling logic that's rarely used. Most slides build themselves by calling `widget.create_widget_objects_from_config()`, but there's one method in _slide.py_ that repeats that behavior internally. I've replaced that method with a call to the widget one, for consistency.

UPDATE: Now with tests!