### PR TITLE
Allow conditional events in 'add_to_slide' animations

### DIFF
--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -122,7 +122,7 @@ class Widget(KivyWidget):
         # Build animations
         if 'animations' in self.config and self.config['animations']:
             for k, v in self.config['animations'].items():
-                if k == 'add_to_slide':
+                if k.split("{")[0] == 'add_to_slide':
                     # needed because the initial properties of the widget
                     # aren't set yet
                     Clock.schedule_once(self.on_add_to_slide, -1)
@@ -628,7 +628,11 @@ class Widget(KivyWidget):
         if 'add_to_slide' in self.config['reset_animations_events']:
             self.reset_animations()
 
-        self.start_animation_from_event('add_to_slide')
+        for k in self.config['animations'].keys():
+            event, placeholder = self.mc.events.get_event_and_condition_from_string(k);
+            if event == 'add_to_slide' and (not placeholder or placeholder.evaluate({})):
+                self.start_animation_from_event(k)
+                break
 
     def on_remove_from_slide(self) -> None:
         """Automatically called when this widget is removed from a slide.

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -629,7 +629,7 @@ class Widget(KivyWidget):
             self.reset_animations()
 
         for k in self.config['animations'].keys():
-            event, placeholder = self.mc.events.get_event_and_condition_from_string(k);
+            event, placeholder = self.mc.events.get_event_and_condition_from_string(k)
             if event == 'add_to_slide' and (not placeholder or placeholder.evaluate({})):
                 self.start_animation_from_event(k)
                 break


### PR DESCRIPTION
This PR extends the logic of `widget:animations:add_to_slide` to allow conditional events on the animation.

There are a number of magic events for widget animations—this PR only addresses "add_to_slide" as a way to test/validate the approach. If it works well, the same could be implemented across other animation events. If not, or if the events are shifted to a different approach, less work to refactor.

```
red_alert_widget:
  - type: rectangle
    width: 121
    height: 158
    animations:
      add_to_slide{current_player.redalert}: pulse_fast
```