### PR TITLE
Bugfix fallback for 'use_sound_setting' on track play

### DIFF
--- a/mpfmc/config_players/sound_player.py
+++ b/mpfmc/config_players/sound_player.py
@@ -102,8 +102,7 @@ Here are several various examples:
             action = s['action'].lower()
             del s['action']
 
-            s.setdefault('track', sound.track)
-            track = self.machine.sound_system.audio_interface.get_track_by_name(s['track'])
+            track = self.machine.sound_system.audio_interface.get_track_by_name(s.get('track') or sound.track)
             if track is None:
                 self.machine.log.error("SoundPlayer: The specified track ('{}') "
                                        "does not exist. Unable to perform '{}' action "


### PR DESCRIPTION
This PR is in tandem with https://github.com/missionpinball/mpf/pull/1302 and attempts to fix errors related to `"use_sound_setting"` being passed in lieu of a valid sound setting value.

The linked PR eliminates "use_sound_setting" as a default value and replaces it with `None`. However, in a Python dictionary, `None` is a valid value and therefore `setdefault()` has no effect. Therefore, the linked PR breaks the SoundPlayer's track behavior because it won't identify a `None` track as needing to use the sound setting.

This PR changes the track selection behavior to evaluate the truthiness of the SoundPlayer track. 
Instead of `s.setdefault('track', sound.track)` the logic uses `s.get('track') or sound.track`.

The result is that the SoundPlayer will use sound setting whether its own track is undefined or `None`.