### PR TITLE
Handle optional “slide” param, honor “slide:” in widgets [Backport]

### DIFF
--- a/mpfmc/config_players/slide_player.py
+++ b/mpfmc/config_players/slide_player.py
@@ -117,7 +117,7 @@ class McSlidePlayer(McConfigPlayer):
 
             s.update(kwargs)
 
-            if s["slide"]:
+            if s.get("slide"):
                 slide = s['slide']
 
             try:

--- a/mpfmc/config_players/widget_player.py
+++ b/mpfmc/config_players/widget_player.py
@@ -29,15 +29,13 @@ class McWidgetPlayer(McConfigPlayer):
 
     def _get_slide(self, s):
         slide = None
-
-        if 'slide' in s and s['slide']:
-            slide_name = s.pop('slide')
+        if s.get('slide'):
+            slide_name = s['slide']
             try:
                 slide = self.machine.active_slides[slide_name]
             except KeyError:
                 # check if slide does exist
                 if slide_name not in self.machine.slides:
-                    s['slide'] = slide_name
                     raise KeyError(
                         "Widget Player Error: Slide name '{}' is not valid "
                         "slide. Widget config that caused this: "

--- a/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
+++ b/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
@@ -263,6 +263,13 @@ widget_player:
   add_widget2_to_slide1:
     widget2:
       slide: slide1
+  update_widget2:
+    widget2:
+      action: update
+      slide: slide1
+  remove_widget2:
+    widget2:
+      action: remove
   add_widget6:
     widget6:
       widget_settings:

--- a/mpfmc/tests/test_Widget.py
+++ b/mpfmc/tests/test_Widget.py
@@ -475,7 +475,30 @@ class TestWidget(MpfMcTestCase):
         self.mc.events.post('add_widget2_to_slide1')
         self.advance_time()
 
-        # widget1 should be in slide1, not slide2, not current slide
+        # widget2 should be in slide1, not slide2, not current slide
+        self.assertIn('widget2',
+                      [x.widget.text for x in
+                       self.mc.active_slides['slide1'].widgets])
+        self.assertNotIn('widget2',
+                         [x.widget.text for x in
+                          self.mc.active_slides['slide2'].widgets])
+        self.assertNotIn('widget2', [x.widget.text for x in self.mc.targets[
+            'default'].current_slide.widgets])
+
+        # Remove widget2
+        self.mc.events.post('remove_widget2')
+        self.advance_time()
+
+        # widget2 should not be present in slide1
+        self.assertNotIn('widget2',
+                         [x.widget.text for x in
+                          self.mc.active_slides['slide1'].widgets])
+
+        # Update widget2 on slide1
+        self.mc.events.post('update_widget2')
+        self.advance_time()
+
+        # widget2 should be in slide1, not slide2, not current slide
         self.assertIn('widget2',
                       [x.widget.text for x in
                        self.mc.active_slides['slide1'].widgets])


### PR DESCRIPTION
This PR backports https://github.com/missionpinball/mpf-mc/pull/363 for merge into 0.51, including tests.

No compatibility issues are expected, because this PR does not change any MC behavior. It only changes some direct dictionary access calls with `.get()` calls to gracefully handle non-present values.