### PR TITLE
#1304 Remove "verbose" keyword from namedtuple (Python 3.7)

### DIFF
--- a/mpfmc/core/mode.py
+++ b/mpfmc/core/mode.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 
 RemoteMethod = namedtuple('RemoteMethod',
                           'method config_section kwargs priority',
-                          verbose=False)
+                          )
 """RemotedMethod is used by other modules that want to register a method to
 be called on mode_start or mode_stop.
 """

--- a/mpfmc/core/mode_controller.py
+++ b/mpfmc/core/mode_controller.py
@@ -11,7 +11,7 @@ from mpfmc.core.mode import Mode
 
 RemoteMethod = namedtuple('RemoteMethod',
                           'method config_section kwargs priority',
-                          verbose=False)
+                          )
 """RemotedMethod is used by other modules that want to register a method to
 be called on mode_start or mode_stop.
 """


### PR DESCRIPTION
Related to https://github.com/missionpinball/mpf/issues/1304 wherein Python3.7 removed support for `verbose` in namedtuples. `False` is the default value and I didn't see anywhere where it was overridden, so this change shouldn't impact any other behavior or Python versions.

Unfortunately my local tests are having difficulty, so I'm creating this PR to trigger Travis and see what that turns up. 

Do not recommend merging this until tests are validated.