### PR TITLE
Include priority in widget add_to_slide

### DIFF
--- a/mpfmc/config_players/widget_player.py
+++ b/mpfmc/config_players/widget_player.py
@@ -78,12 +78,14 @@ class McWidgetPlayer(McConfigPlayer):
 
             return
 
+        priority = s.pop("priority", 1)
+
         if 'slide' in s and s['slide']:
             if s['key'] in instance_dict and isinstance(instance_dict[s['key']], EventHandlerKey):
                 self.machine.events.remove_handler_by_key(instance_dict[s['key']])
             handler = self.machine.events.add_handler(
                 "slide_{}_created".format(s['slide']), self._add_widget_to_slide_when_active,
-                slide_name=s['slide'], widget=widget, s=s, play_kwargs=play_kwargs)
+                slide_name=s['slide'], widget=widget, s=s, priority=priority, play_kwargs=play_kwargs)
             instance_dict[s['key']] = handler
 
         try:
@@ -138,7 +140,6 @@ class McWidgetPlayer(McConfigPlayer):
             settings = settings['widgets']
 
         for widget, s in settings.items():
-            s.pop('priority', None)
             action = s.pop('action')
             assert action in ('add', 'remove', 'update')
 


### PR DESCRIPTION
When a WidgetPlayer adds a Widget to an explicit slide (via the `slide:` parameter) and that slide is not active, it creates an event handler for the _slide_slidename_created_ event with a callback to `widget_player._add_widget_to_slide_when_active()`.

As part of this process, the WidgetPlayer explicitly removes the `priority` parameter from the player config. As a result, if multiple widgets are being added to a slide, a `Duplicate event handler` warning is logged because all of the _slide_slidename_created_ handlers have priority 1.

This PR changes that behavior by allowing the WidgetPlayer config to read a `priority` parameter and pass that value into the event handler.

```
widget_player:
  mineral_shot_iridium_hit:
    mineral_highlight:
      action: update
      key: mineral_highlight_iridium
      slide: minerals_slide
      priority: 1
      widget_settings:
        expire: 200ms
        style: mineral_highlight_pos_iridium
  mineral_shot_palladium_hit:
    mineral_highlight:
      action: update
      key: mineral_highlight_palladium
      slide: minerals_slide
      priority: 2
      widget_settings:
        expire: 200ms
        style: mineral_highlight_pos_palladium
  mineral_shot_platinum_hit:
    mineral_highlight:
      action: update
      key: mineral_highlight_platinum
      slide: minerals_slide
      priority: 3
      widget_settings:
        expire: 200ms
        style: mineral_highlight_pos_platinum
```

The only side effect of this change is that the `priority` field persists in the WidgetPlayer settings longer than it did before. I don't foresee this causing any issues, but I'm interested as to why the priority was explicitly removed in the first place.