### PR TITLE
Widget custom events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+~/
 env/
 build/
 develop-eggs/

--- a/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
+++ b/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
@@ -403,8 +403,12 @@ widget_player:
   show_text_widget: widget_text
   show_custom_events1_widget: widget_custom_events1
   show_custom_events2_widget: widget_custom_events2
-  remove_custom_events1_widget: widget_custom_events1
-  remove_custom_events2_widget: widget_custom_events2
+  remove_custom_events1_widget:
+    widget_custom_events1:
+      action: remove
+  remove_custom_events2_widget:
+    widget_custom_events2:
+      action: remove
 
 slide_player:
   show_slide_1:
@@ -490,6 +494,11 @@ slide_player:
         text: NEW SLIDE
         y: 0
         anchor_y: bottom
+        events_when_added: text_on_new_slide2_added
+        events_when_removed: text_on_new_slide2_removed
+  remove_new_slide:
+    new_slide2:
+      action: remove
 
 slides:
     slide_with_lots_of_widgets:

--- a/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
+++ b/mpfmc/tests/machine_files/widgets/config/test_widgets.yaml
@@ -256,6 +256,20 @@ widgets:
   widget_placeholder_value2:
     - type: text
       text: Value Two
+  widget_custom_events1:
+    - type: text
+      text: Testing events
+      events_when_added: custom_events1_added
+      events_when_removed: custom_events1_removed
+  widget_custom_events2:
+    - type: rectangle
+      x: 600
+      y: 300
+      width: 100
+      height: 200
+      color: gold
+      events_when_added: custom_events2_added, custom_events2_added_again
+      events_when_removed: custom_events2_removed, custom_events2_removed_again
 
 widget_player:
   add_widget1_to_current: widget1
@@ -387,6 +401,10 @@ widget_player:
   show_triangle_widget: widget_triangle
   show_points_widget: widget_points
   show_text_widget: widget_text
+  show_custom_events1_widget: widget_custom_events1
+  show_custom_events2_widget: widget_custom_events2
+  remove_custom_events1_widget: widget_custom_events1
+  remove_custom_events2_widget: widget_custom_events2
 
 slide_player:
   show_slide_1:

--- a/mpfmc/tests/test_Widget.py
+++ b/mpfmc/tests/test_Widget.py
@@ -1272,10 +1272,22 @@ class TestWidget(MpfMcTestCase):
         self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events2_added_again')
 
         self.mc.events.post('remove_custom_events1_widget')
-        self.advance_real_time()
+        self.advance_real_time(0.1)
         self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events1_removed')
 
         self.mc.events.post('remove_custom_events2_widget')
         self.advance_real_time()
         self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events2_removed')
         self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events2_removed_again')
+
+        self.mc.bcp_processor.send.reset_mock()
+        self.mc.events.post('show_new_slide')
+        self.advance_real_time()
+        self.mc.bcp_processor.send.assert_any_call('trigger', name='text_on_new_slide2_added')
+
+        self.mc.events.post('show_slide_1')
+        self.mc.events.post('remove_new_slide')
+        self.advance_real_time()
+        self.mc.bcp_processor.send.assert_any_call('trigger', name='text_on_new_slide2_removed')
+
+

--- a/mpfmc/tests/test_Widget.py
+++ b/mpfmc/tests/test_Widget.py
@@ -1253,3 +1253,30 @@ class TestWidget(MpfMcTestCase):
         self.assertEqual(triangle_widget.rotation, -900)
         self.assertEqual(triangle_widget.scale, 1.5)
         self.assertEqual(triangle_widget.points, [100, 450, 100, 550, 200, 450])
+
+    def test_events_when_removed(self):
+        """Test events_when_removed property to ensure custom events are posted."""
+
+        # Mock BCP send method
+        self.mc.bcp_processor.send = MagicMock()
+        self.mc.bcp_processor.enabled = True
+
+        self.mc.events.post('show_custom_events1_widget')
+        self.advance_real_time()
+        self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events1_added')
+
+        self.mc.events.post('show_custom_events2_widget')
+        self.advance_real_time()
+        self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events2_added')
+        self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events2_added_again')
+
+        self.mc.events.post('remove_custom_events1_widget')
+        self.advance_real_time()
+        self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events1_removed')
+
+        self.mc.events.post('remove_custom_events2_widget')
+        self.advance_real_time()
+        self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events2_removed')
+        self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events2_removed_again')
+
+

--- a/mpfmc/tests/test_Widget.py
+++ b/mpfmc/tests/test_Widget.py
@@ -13,6 +13,7 @@ from mpfmc.widgets.quad import Quad
 from mpfmc.widgets.point import Point
 from mpfmc.widgets.triangle import Triangle
 from mpfmc.tests.MpfMcTestCase import MpfMcTestCase
+from unittest.mock import MagicMock, call, ANY
 
 
 class TestWidget(MpfMcTestCase):

--- a/mpfmc/tests/test_Widget.py
+++ b/mpfmc/tests/test_Widget.py
@@ -13,7 +13,7 @@ from mpfmc.widgets.quad import Quad
 from mpfmc.widgets.point import Point
 from mpfmc.widgets.triangle import Triangle
 from mpfmc.tests.MpfMcTestCase import MpfMcTestCase
-from unittest.mock import MagicMock, call, ANY
+from unittest.mock import MagicMock
 
 
 class TestWidget(MpfMcTestCase):
@@ -1279,5 +1279,3 @@ class TestWidget(MpfMcTestCase):
         self.advance_real_time()
         self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events2_removed')
         self.mc.bcp_processor.send.assert_any_call('trigger', name='custom_events2_removed_again')
-
-

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -143,6 +143,11 @@ class Widget(KivyWidget):
         if self.expire:
             self.schedule_removal(self.expire)
 
+        # Send custom user events when widget is added (if any are configured)
+        if self.config['events_when_added'] is not None:
+            for event in self.config['events_when_added']:
+                self.mc.post_mc_native_event(event)
+
     def __repr__(self) -> str:  # pragma: no cover
         return '<{} Widget id={}>'.format(self.widget_type_name, self.id)
 
@@ -437,6 +442,11 @@ class Widget(KivyWidget):
             pass
 
         self.on_remove_from_slide()
+
+        # Send custom user events when widget is removed (if any are configured)
+        if self.config['events_when_removed'] is not None:
+            for event in self.config['events_when_removed']:
+                self.mc.post_mc_native_event(event)
 
     def _convert_animation_value_to_float(self, prop: str,
                                           val: Union[str, int, float], event_args) -> Union[float, int]:

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -424,6 +424,11 @@ class Widget(KivyWidget):
         self.stop_animation()
         self._remove_animation_events()
 
+        # Send custom user events when widget is removed (if any are configured)
+        if self.config['events_when_removed'] is not None:
+            for event in self.config['events_when_removed']:
+                self.mc.post_mc_native_event(event)
+
     def schedule_removal(self, secs: float) -> None:
         """Schedule the widget to be removed after the specified number
         of seconds have elapsed."""
@@ -442,11 +447,6 @@ class Widget(KivyWidget):
             pass
 
         self.on_remove_from_slide()
-
-        # Send custom user events when widget is removed (if any are configured)
-        if self.config['events_when_removed'] is not None:
-            for event in self.config['events_when_removed']:
-                self.mc.post_mc_native_event(event)
 
     def _convert_animation_value_to_float(self, prop: str,
                                           val: Union[str, int, float], event_args) -> Union[float, int]:


### PR DESCRIPTION
Fixes MPF issue 1332 (No widget remove event) along with MPF PR 1338.  Adds optional custom events for widget added and widget removed events using new widget properties events_when_added and events_when_removed.