### PR TITLE
Known-good tests for conditional slides

### DIFF
--- a/mpfmc/config_players/slide_player.py
+++ b/mpfmc/config_players/slide_player.py
@@ -101,7 +101,6 @@ class McSlidePlayer(McConfigPlayer):
         """Process a slide_player event."""
         instance_dict = self._get_instance_dict(context)
         full_context = self._get_full_context(context)
-        settings = deepcopy(settings)
 
         self.machine.log.info("SlidePlayer: Play called with settings=%s", settings)
 
@@ -113,6 +112,7 @@ class McSlidePlayer(McConfigPlayer):
                     continue
                 slide = slide.name
 
+            s = deepcopy(s)
             s.update(kwargs)
 
             if s.get("slide"):

--- a/mpfmc/tests/machine_files/slide_player/config/test_slide_player.yaml
+++ b/mpfmc/tests/machine_files/slide_player/config/test_slide_player.yaml
@@ -14,6 +14,12 @@ slides:
   slide_with_var:
     - type: text
       text: SLIDE WITH VAR (test)
+  slide_condition_foo:
+    - type: text
+      text: Conditional Slide (FOO)
+  slide_condition_bar:
+    - type: text
+      text: Conditional Slide (BAR)
   machine_slide_1:
     - type: text
       text: TEST SLIDE PLAYER - SLIDE 1
@@ -247,3 +253,8 @@ slide_player:
     slide_with_var:
       tokens:
         test: asd
+  show_conditional_slide:
+    slide_condition_foo{var=="foo"}:
+      action: play
+    slide_condition_bar{var=="bar"}:
+      action: play

--- a/mpfmc/tests/test_SlidePlayer.py
+++ b/mpfmc/tests/test_SlidePlayer.py
@@ -580,6 +580,16 @@ class TestSlidePlayer(MpfMcTestCase):
             # build weak ref to curent slide
             slide = weakref.ref(self.mc.targets['display1'].current_slide)
 
+    def test_conditional_slide(self):
+        self.mc.events.post('show_conditional_slide', var='foo')
+        self.advance_time()
+        self.assertEqual(self.mc.targets['display1'].current_slide_name,
+                         'slide_condition_foo')
+        self.mc.events.post('show_conditional_slide', var='bar')
+        self.advance_time()
+        self.assertEqual(self.mc.targets['display1'].current_slide_name,
+                         'slide_condition_bar')
+
 
 class TestMpfSlidePlayer(MpfTestCase):
 


### PR DESCRIPTION
This PR adds some tests to cover conditional slides (https://github.com/missionpinball/mpf-mc/pull/307). These tests will fail CI because of a regression in https://github.com/missionpinball/mpf-mc/pull/381 (a regression that wasn't caught because I didn't write these tests when I should have).

I'm investigating a fix, but pinging @jabdoa2 since you can probably fix it way faster than me.