### PR TITLE
Fix DMD Gamma Test slide

### DIFF
--- a/mpfmc/mcconfig.yaml
+++ b/mpfmc/mcconfig.yaml
@@ -170,7 +170,7 @@ slides:
     widgets:
       - type: text
         text: DMD GAMMA TEST
-        style: dmd_small
+        style: small
         y: 4
         anchor_x: left
         x: 2


### PR DESCRIPTION
Following the guide for [gamma correction](http://docs.missionpinball.org/en/latest/config/instructions/gamma_correction.html), I tried to use the built in dmd_gamma_test slide and kept crashing with:
`Shutdown reason: BCP client local_display disconnected and exit_on_close is set`

Eventually I copied over the built-in slide code from this repo, and found that it was breaking on `style: dmd_small`:
https://github.com/missionpinball/mpf-mc/blob/efb6bfe5e58826e6545998a0ae9d7108e51ca1e3/mpfmc/mcconfig.yaml#L173

It looks like these styles were recently renamed, and sure enough, replacing `dmd_small` with `small` works great.

This section of docs will probably need to be updated as well: http://docs.missionpinball.org/en/latest/displays/widgets/dmd_fonts.html