### PR TITLE
Predictable mode load order

### DIFF
--- a/mpfmc/core/mode_controller.py
+++ b/mpfmc/core/mode_controller.py
@@ -59,10 +59,9 @@ class ModeController:
         mode_configs = [self._load_mode(mode) for mode in set(self.mc.machine_config['modes'])]
         # Instantiate Modes based on load_priority to ensure dependencies go first
         for mode_config in sorted(mode_configs, reverse = True, key = lambda x: x[0]):
-            config, mode_string, mode_path, asset_paths = *mode_config[1:]
+            config, mode_string, mode_path, asset_paths = mode_config[1:]
             self.mc.config_validator.validate_config("mode", config['mode'])
-            self.mc.modes[mode_string] =
-                Mode(self.mc, config, mode_string, mode_path, asset_paths)
+            self.mc.modes[mode_string] = Mode(self.mc, config, mode_string, mode_path, asset_paths)
 
 
 
@@ -150,7 +149,7 @@ class ModeController:
 
         load_priority = config['mode'].get('load_priority', 0)
         return [
-            load_priority
+            load_priority,
             config,
             mode_string,
             mode_path,


### PR DESCRIPTION
This PR changes the behavior of MC loading modes by splitting the logic into two phases.

Previously, MC would iterate through each mode, load the config file, traverse the structure, validate the configuration and return a parsed/typed/defaulted object, and instantiate a Mode class from the config.

In this change, MC iterates through each mode, loads the config files, and traverses the structures. It then looks for a (new) mode configuration setting `load_priority` and sorts the modes based on it. From that sorting, it iterates through the modes and validates the configuration, gets a parsed/type/defaulted object, and instantiates a Mode class from the config.

**WHY?**
Because the modes arrive as a dict, the order in which they are validated and instantiated is unpredictable. This can have adverse affects when modes share config_player keys.

For example, a base mode may define a slide and a number of widgets that other modes use. If the base mode is loaded first, the other modes are able to validate that the slide and widgets exist and MC boots. If one of the other modes is loaded first, it throws an error that the specified slide/widget name does not exist.

**THE FIX**
By allowing certain modes to be explicitly loaded in a predictable order, a creator can create slides, widgets, and other MC-based config_player values to share. This reduces code duplication and improves the reliability of the game.

I did not extend this functionality to MPF mode loading... yet. There aren't as many obvious cases where MPF config_players share values, and the mode loading business in MPF is more complex. This PR is a proof-of-concept for the prioritization of loading, and could be extended to MPF if desired.