### PR TITLE
Add glow effect

### DIFF
--- a/mpfmc/effects/glow.py
+++ b/mpfmc/effects/glow.py
@@ -1,6 +1,7 @@
 from kivy.properties import NumericProperty
 from kivy.uix.effectwidget import EffectBase
 
+
 class GlowEffect(EffectBase):
 
     """GLSL effect to apply a glowing effect to a texture."""
@@ -31,6 +32,7 @@ class GlowEffect(EffectBase):
                                      float(self.intensity),
                                      float(self.glow_amplitude),
                                      float(self.glow_speed))
+
 
 glow_glsl = '''
 vec4 effect(vec4 color, sampler2D texture, vec2 tex_coords, vec2 coords)

--- a/mpfmc/effects/glow.py
+++ b/mpfmc/effects/glow.py
@@ -1,0 +1,67 @@
+from kivy.properties import NumericProperty
+from kivy.uix.effectwidget import EffectBase
+
+class GlowEffect(EffectBase):
+
+    """GLSL effect to apply a glowing effect to a texture."""
+
+    blur_size = NumericProperty(4.0)
+    intensity = NumericProperty(.5)
+    glow_amplitude = NumericProperty(0.1)
+    glow_speed = NumericProperty(1.0)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.do_glsl()
+
+    def on_blur_size(self, *args):
+        self.do_glsl()
+
+    def on_intensity(self, *args):
+        self.do_glsl()
+
+    def on_glow_speed(self, *args):
+        self.do_glsl()
+
+    def on_glow_amplitude(self, *args):
+        self.do_glsl()
+
+    def do_glsl(self):
+        self.glsl = glow_glsl.format(float(self.blur_size),
+                                     float(self.intensity),
+                                     float(self.glow_amplitude),
+                                     float(self.glow_speed))
+
+glow_glsl = '''
+vec4 effect(vec4 color, sampler2D texture, vec2 tex_coords, vec2 coords)
+{{
+    float blurSize = {0}/resolution.x;
+    vec4 sum = vec4(0.0);
+    sum += texture(texture, vec2(tex_coords.x - 4.0 * blurSize, tex_coords.y)) * .05;
+    sum += texture(texture, vec2(tex_coords.x - 3.0*blurSize, tex_coords.y)) * 0.09;
+    sum += texture(texture, vec2(tex_coords.x - 2.0*blurSize, tex_coords.y)) * 0.12;
+    sum += texture(texture, vec2(tex_coords.x - blurSize, tex_coords.y)) * 0.15;
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y)) * 0.16;
+    sum += texture(texture, vec2(tex_coords.x + blurSize, tex_coords.y)) * 0.15;
+    sum += texture(texture, vec2(tex_coords.x + 2.0*blurSize, tex_coords.y)) * 0.12;
+    sum += texture(texture, vec2(tex_coords.x + 3.0*blurSize, tex_coords.y)) * 0.09;
+    sum += texture(texture, vec2(tex_coords.x + 4.0*blurSize, tex_coords.y)) * 0.05;
+
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y - 4.0*blurSize)) * 0.05;
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y - 3.0*blurSize)) * 0.09;
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y - 2.0*blurSize)) * 0.12;
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y - blurSize)) * 0.15;
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y)) * 0.16;
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y + blurSize)) * 0.15;
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y + 2.0*blurSize)) * 0.12;
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y + 3.0*blurSize)) * 0.09;
+    sum += texture(texture, vec2(tex_coords.x, tex_coords.y + 4.0*blurSize)) * 0.05;
+
+    vec4 result = texture(texture, tex_coords);
+    result = sum * ({2}*sin(2*3.14*{3}*time) + {1})  + result;
+    return result;
+}}
+'''
+
+effect_cls = GlowEffect
+name = 'glow'

--- a/mpfmc/mcconfig.yaml
+++ b/mpfmc/mcconfig.yaml
@@ -41,6 +41,7 @@ mpf-mc:
         - flip_vertical
         - gain
         - gamma
+        - glow
         - monochrome
         - reduce
 


### PR DESCRIPTION
I've been working recently on emulating a segment display for my game.  It needed a glowing type of shader effect in order to achieve a convincing result so I decided to add one to my local copy of mpf-mc.  Posting this PR in case you think others might find it useful.  This is just a general effect, so users who want to emulate a segment display would have to set up the fonts and such using widgets in their own game.  Ideally, I think it would be best to have a way to specify a segment display in an mpf config and have it work with minimal setup but I don't know enough about kivy or mpf-mc yet to do that.

One interesting thing I learned is that the glsl shaders we pass to Kivy have access to a `time` variable which is the elapsed time since the shader started.  With this you can write other effects for MPF that respond to time, like this one does.  Other effects could be updated to use this, especially `colorize`. 

Example w/o effect:
https://gph.is/g/ZddoMN3

Example w/ effect:
https://gph.is/g/4MoW7gw