### PR TITLE
Trigger new events in shift and select calls of the text_input widget

### DIFF
--- a/mpfmc/widgets/text_input.py
+++ b/mpfmc/widgets/text_input.py
@@ -147,7 +147,7 @@ class MpfTextInput(Text):
             self.current_list.rotate(-places)
 
             self.mc.post_mc_native_event('text_input_{}_active_character'.format(self.key),
-                                        text=self.current_list[0])
+                                         text=self.current_list[0])
 
             if self.current_list[0] == 'end':
                 self.font_size = self.config['font_size'] / 2
@@ -197,7 +197,7 @@ class MpfTextInput(Text):
                 self.complete()
 
         self.mc.post_mc_native_event('text_input_{}_select'.format(self.key),
-                text=self.linked_text_widget.text, length=len(self.linked_text_widget.text))
+                                     text=self.linked_text_widget.text, length=len(self.linked_text_widget.text))
 
     def set_relative_position(self, *args) -> None:
         del args

--- a/mpfmc/widgets/text_input.py
+++ b/mpfmc/widgets/text_input.py
@@ -146,6 +146,9 @@ class MpfTextInput(Text):
         if self.active or force:
             self.current_list.rotate(-places)
 
+            self.mc.post_mc_native_event('text_input_{}_active_character'.format(self.key),
+                                        text=self.current_list[0])
+
             if self.current_list[0] == 'end':
                 self.font_size = self.config['font_size'] / 2
                 self.update_text('END')
@@ -192,6 +195,9 @@ class MpfTextInput(Text):
             if len(self.linked_text_widget.text) > self.config['max_chars']:
                 # we are done
                 self.complete()
+
+        self.mc.post_mc_native_event('text_input_{}_select'.format(self.key),
+                text=self.linked_text_widget.text, length=len(self.linked_text_widget.text))
 
     def set_relative_position(self, *args) -> None:
         del args


### PR DESCRIPTION
New events added to text_input widget. Added text_input_{}_select event when a character is selected in the widget. The event contains the current value of the text widget and length for handlers to use. Added text_input_{}_active_character event when the active character is cycled. The event contains the newly active character for handlers to use.