### PR TITLE
Allow block_events and release_events on TextInput

### DIFF
--- a/mpfmc/tests/machine_files/text_input/config/text_input.yaml
+++ b/mpfmc/tests/machine_files/text_input/config/text_input.yaml
@@ -25,6 +25,8 @@ slides:
         value: 0
         duration: .25s
         repeat: yes
+    block_events: test_block
+    release_events: test_release
   - type: text
     text: ""
     key: key1

--- a/mpfmc/tests/test_TextInput.py
+++ b/mpfmc/tests/test_TextInput.py
@@ -207,3 +207,40 @@ class TestText(MpfMcTestCase):
         self.mc.events.post('sw_start')
         self.advance_time()
         self.assertEqual(text_display_widget.text, 'MPF')
+
+    def test_text_input_blocking(self):
+        self.mc.events.post('slide1')
+        self.advance_time(1)
+
+        text_input_widget = (
+            self.mc.targets['default'].current_slide.widgets[1].widget)
+
+        text_display_widget = (
+            self.mc.targets['default'].current_slide.widgets[2].widget)
+
+        self.assertEqual(text_display_widget.text, '')
+        self.assertEqual(text_input_widget.text, 'C')
+        self.advance_time()
+
+        self.mc.events.post('sw_left_flipper')
+        self.advance_time()
+        self.assertEqual(text_input_widget.text, 'B')
+        self.mc.events.post('sw_right_flipper')
+        self.advance_time()
+        self.assertEqual(text_input_widget.text, 'C')
+        self.mc.events.post('test_block')
+        self.advance_time()
+        self.mc.events.post('sw_right_flipper')
+        self.advance_time()
+        self.assertEqual(text_input_widget.text, 'C')
+        self.mc.events.post('sw_left_flipper')
+        self.advance_time()
+        self.assertEqual(text_input_widget.text, 'C')
+        self.mc.events.post('test_release')
+        self.advance_time()
+        self.mc.events.post('sw_right_flipper')
+        self.advance_time()
+        self.assertEqual(text_input_widget.text, 'D')
+        self.mc.events.post('sw_left_flipper')
+        self.advance_time()
+        self.assertEqual(text_input_widget.text, 'C')

--- a/mpfmc/widgets/text_input.py
+++ b/mpfmc/widgets/text_input.py
@@ -49,6 +49,7 @@ class MpfTextInput(Text):
         self.final_list = deque()
         self.final_list.append('back')
         self.final_list.append('end')
+        self._is_blocking = False
 
         Clock.schedule_once(self.find_linked_text_widget)
 
@@ -103,6 +104,17 @@ class MpfTextInput(Text):
             self.config['force_complete_event'] = (
                 'text_input_{}_force_complete'.format(self.key))
 
+        for event in self.config.get('block_events',[]):
+            self.registered_event_handlers.add(self.mc.events.add_handler(
+                event, self.block_enable, priority=2  # Priority avoids conflicts with select/abort event handlers
+            ))
+            self.mc.bcp_processor.register_trigger(event)
+        for event in self.config.get('release_events',[]):
+            self.registered_event_handlers.add(self.mc.events.add_handler(
+                event, self.block_disable, priority=2
+            ))
+            self.mc.bcp_processor.register_trigger(event)
+
         self.registered_event_handlers.add(self.mc.events.add_handler(
             self.config['shift_left_event'], self.shift, places=-1))
         self.mc.bcp_processor.register_trigger(self.config['shift_left_event'])
@@ -143,6 +155,8 @@ class MpfTextInput(Text):
 
     def shift(self, places: int = 1, force: bool = False, **kwargs) -> None:
         del kwargs
+        if self._is_blocking:
+            return
         if self.active or force:
             self.current_list.rotate(-places)
 
@@ -244,6 +258,14 @@ class MpfTextInput(Text):
     def prepare_for_removal(self) -> None:
         self.done()
         super().prepare_for_removal()
+
+    def block_enable(self, **kwargs) -> None:
+        del kwargs
+        self._is_blocking = True
+
+    def block_disable(self, **kwargs) -> None:
+        del kwargs
+        self._is_blocking = False
 
 
 widget_classes = [MpfTextInput]

--- a/mpfmc/widgets/text_input.py
+++ b/mpfmc/widgets/text_input.py
@@ -104,12 +104,12 @@ class MpfTextInput(Text):
             self.config['force_complete_event'] = (
                 'text_input_{}_force_complete'.format(self.key))
 
-        for event in self.config.get('block_events',[]):
+        for event in self.config.get('block_events', []):
             self.registered_event_handlers.add(self.mc.events.add_handler(
                 event, self.block_enable, priority=2  # Priority avoids conflicts with select/abort event handlers
             ))
             self.mc.bcp_processor.register_trigger(event)
-        for event in self.config.get('release_events',[]):
+        for event in self.config.get('release_events', []):
             self.registered_event_handlers.add(self.mc.events.add_handler(
                 event, self.block_disable, priority=2
             ))


### PR DESCRIPTION
This PR extends the `block_events` and `release_events` added to Carousel in https://github.com/missionpinball/mpf/pull/1535 and adds them to the TextInput element. 

This provides a cleaner mechanism for using flipper_cancel to select items without triggering accidental forward/backward navigations with the release flipper presses.