### PR TITLE
Exception wrapping

### DIFF
--- a/mpfmc/assets/sound.py
+++ b/mpfmc/assets/sound.py
@@ -623,7 +623,8 @@ class SoundAsset(McAsset):
         except AudioException as exception:
             self.log.error("Load sound %s failed due to an exception - %s",
                            self.name, str(exception))
-            raise AudioException("Load sound {} failed due to an exception: {}".format(self.name, exception)) from exception
+            raise AudioException("Load sound {} failed due to an exception: {}".format(
+                self.name, exception)) from exception
 
         # Validate ducking now that the sound has been loaded
         # TODO: Implement me

--- a/mpfmc/assets/sound.py
+++ b/mpfmc/assets/sound.py
@@ -623,7 +623,7 @@ class SoundAsset(McAsset):
         except AudioException as exception:
             self.log.error("Load sound %s failed due to an exception - %s",
                            self.name, str(exception))
-            raise
+            raise AudioException("Load sound {} failed due to an exception: {}".format(self.name, exception)) from exception
 
         # Validate ducking now that the sound has been loaded
         # TODO: Implement me

--- a/mpfmc/core/config_collection.py
+++ b/mpfmc/core/config_collection.py
@@ -1,6 +1,7 @@
 from importlib import import_module
 
 from mpf.core.device_manager import DeviceCollection
+from mpf.exceptions.config_file_error import ConfigFileError
 
 MYPY = False
 if MYPY:    # pragma: no cover
@@ -52,8 +53,11 @@ class ConfigCollection(DeviceCollection):
             # if not settings:
             #     raise AssertionError("{} entry '{}' has an empty config."
             #                          .format(self.config_section, name))
-
-            self[name] = self.process_config(settings)
+            try:
+                self[name] = self.process_config(settings)
+            except ConfigFileError as e:
+                raise ConfigFileError("Error creating {} config entry for '{}' >> {}".format(
+                    self.config_section, name, e._message), e._error_no, e._logger_name) from e
 
     def validate_entries_from_root_config(self, **kwargs):
         del kwargs

--- a/mpfmc/core/config_collection.py
+++ b/mpfmc/core/config_collection.py
@@ -56,8 +56,8 @@ class ConfigCollection(DeviceCollection):
             try:
                 self[name] = self.process_config(settings)
             except ConfigFileError as e:
-                raise ConfigFileError("Error creating {} config entry for '{}' >> {}".format(
-                    self.config_section, name, e._message), e._error_no, e._logger_name) from e
+                e.extend("Error creating {} config entry for '{}'".format(self.config_section, name))
+                raise e
 
     def validate_entries_from_root_config(self, **kwargs):
         del kwargs

--- a/mpfmc/core/mode_controller.py
+++ b/mpfmc/core/mode_controller.py
@@ -72,7 +72,8 @@ class ModeController:
                                     root_config_dict=mode.config,
                                     **item.kwargs)
                 except ConfigFileError as e:
-                    raise ConfigFileError("Error while loading mode '{}' >> {}".format(mode.name, e._message), e._error_no, e._logger_name) from e
+                    e.extend("Error while loading mode '{}'".format(mode.name))
+                    raise e
 
     def _load_mode(self, mode_string):
         """Loads a mode, reads in its config, and creates the Mode object.

--- a/mpfmc/widgets/image.py
+++ b/mpfmc/widgets/image.py
@@ -31,6 +31,7 @@ class ImageWidget(Widget):
         # draws a rectangle using the texture from the loaded image asset to
         # display the image. Scaling and rotation is handled by the Scatter
         # widget.
+        image = None
         try:
             image = self.mc.images[self.config['image']]
         except KeyError:


### PR DESCRIPTION
I've been trying to improve the exception handling of MPF/MC as I work—whenever I get a crash that requires me to scroll through the callstack or look in the logs, I update the Exception chain to try and get the meaningful error into the final callstack message.

I think we should do a 50.4 release soon, so making a PR for the changes I've got so far.