### PR TITLE
Sound player delay, animated image start frame stills

### DIFF
--- a/mpfmc/config_players/sound_player.py
+++ b/mpfmc/config_players/sound_player.py
@@ -111,7 +111,7 @@ Here are several various examples:
                                        .format(s['track'], action, sound_name))
                 return
 
-            # Determine action to perform and store it in a lambda to be executed immediately or after a delay
+            # Determine action to perform
             if action == 'play':
                 track.play_sound(sound, context, s)
 

--- a/mpfmc/config_players/sound_player.py
+++ b/mpfmc/config_players/sound_player.py
@@ -110,28 +110,37 @@ Here are several various examples:
                                        .format(s['track'], action, sound_name))
                 return
 
-            # Determine action to perform
+            delay = s['delay']
+            del s['delay']
+
+            # Determine action to perform and store it in a lambda to be executed immediately or after a delay
+            execute = None
             if action == 'play':
-                track.play_sound(sound, context, s)
+                execute = lambda dt: track.play_sound(sound, context, s)
 
             elif action == 'stop':
                 if 'fade_out' in s:
-                    track.stop_sound(sound, s['fade_out'])
+                    execute = lambda dt: track.stop_sound(sound, s['fade_out'])
                 else:
-                    track.stop_sound(sound)
+                    execute = lambda dt: track.stop_sound(sound)
 
             elif action == 'stop_looping':
-                track.stop_sound_looping(sound)
+                execute = lambda dt: track.stop_sound_looping(sound)
 
             elif action == 'load':
-                sound.load()
+                execute = lambda dt: sound.load()
 
             elif action == 'unload':
-                sound.unload()
+                execute = lambda dt: sound.unload()
 
             else:
                 self.machine.log.error("SoundPlayer: The specified action "
                                        "is not valid ('{}').".format(action))
+
+            if delay:
+                self.machine.clock.schedule_once(execute, delay)
+            else:
+                execute(None)
 
     def get_express_config(self, value):
         """ express config for sounds is simply a string (sound name)"""

--- a/mpfmc/widgets/image.py
+++ b/mpfmc/widgets/image.py
@@ -102,9 +102,12 @@ class ImageWidget(Widget):
         if self._image.image.anim_available:
             self.fps = self.config['fps']
             self.loops = self.config['loops']
-            if self.config['auto_play']:
-                self.play()
-            else:
+            self.start_frame = self.config['start_frame']
+
+            # Always play so we can get the starting frame rendered
+            self.play(start_frame=self.start_frame)
+            # If auto_play is not enabled, immediately stop
+            if not self.config['auto_play']:
                 self.stop()
 
     def _on_texture_change(self, *args) -> None:


### PR DESCRIPTION
This PR implements the `delay` option for SoundPlayer from https://github.com/missionpinball/mpf/pull/1541.

This PR also adds some improved behavior to animated image playback. The `start_frame` setting is applied to the image when playback begins—something that never occurs on images that don't play. This PR tweaks the behavior to always trigger play (thereby jumping to the correct frame) and then immediately stop animations that shouldn't play.

The result of this change is that an image animation can be created to store multiple states of an image (e.g. a progress bar) and a specific frame can be displayed without animating it.