### PR TITLE
Detailed error logging for asset load exceptions

### DIFF
--- a/mpfmc/core/assets.py
+++ b/mpfmc/core/assets.py
@@ -7,6 +7,7 @@ from queue import PriorityQueue, Queue, Empty
 import sys
 
 from mpf.core.assets import BaseAssetManager
+from mpf.exceptions.config_file_error import ConfigFileError
 
 
 class ThreadedAssetManager(BaseAssetManager):
@@ -111,7 +112,12 @@ class AssetLoader(threading.Thread):
                 if asset:
                     with asset.lock:
                         if not asset.loaded:
-                            asset.do_load()
+                            try:
+                                asset.do_load()
+                            except Exception as e:
+                                raise ConfigFileError(
+                                    "Error while loading {} asset file '{}'".format(asset.attribute, asset.file),
+                                    1, self.log.name, asset.name) from e
                             self.loaded_queue.put((asset, True))
                         else:
                             self.loaded_queue.put((asset, False))


### PR DESCRIPTION
This PR adds a ConfigFileError handler to `asset.do_load()`, for detailed information on which asset filename fails to load. 

Prompted by forum discussion https://groups.google.com/g/mpf-users/c/hM65geAlbvY