### PR TITLE
Allow animated images to persist frame in asset

### DIFF
--- a/mpfmc/assets/image.py
+++ b/mpfmc/assets/image.py
@@ -196,7 +196,7 @@ class ImageAsset(McAsset):
     pool_config_section = 'image_pools'  # Will setup groups if present
     asset_group_class = ImagePool  # Class or None to not use pools
 
-    __slots__ = ["frame_skips", "references", "_image"]
+    __slots__ = ["frame_persist", "frame_skips", "references", "_image"]
 
     def __init__(self, mc, name, file, config):
         super().__init__(mc, name, file, config)  # be sure to call super
@@ -205,6 +205,7 @@ class ImageAsset(McAsset):
         # you don't need to do anything.
 
         self._image = None  # holds the actual image in memory
+        self.frame_persist = None
         self.frame_skips = None
         self.references = 0
 

--- a/mpfmc/widgets/image.py
+++ b/mpfmc/widgets/image.py
@@ -103,12 +103,16 @@ class ImageWidget(Widget):
         if self._image.image.anim_available:
             self.fps = self.config['fps']
             self.loops = self.config['loops']
-            self.start_frame = self.config['start_frame']
+            self.start_frame = self._image.image.anim_index if self._image.frame_persist else self.config['start_frame']
             # If not auto playing, set the end index to be the start frame
             if not self.config['auto_play']:
                 # Frame numbers start at 1 and indexes at 0, so subtract 1
                 self._end_index = self.start_frame - 1
             self.play(start_frame=self.start_frame, auto_play=self.config['auto_play'])
+
+            # If this image should persist its animation frame on future loads, set that now
+            if self._image.config.get('persist_frame'):
+                self._image.frame_persist = True
 
     def _on_texture_change(self, *args) -> None:
         """Update texture from image asset (callback when image texture changes)."""


### PR DESCRIPTION
This PR enhances the animated image asset to persist the last frame when the asset is loaded into a new widget.

When the image asset config has `persist_frame: true`, the first time the image asset is loaded the default `start_frame` will be used. On all subsequent loads, the last-used animation frame will be the starting frame.

This change is to improve the behavior of the Digital Score Reels by persisting a player's score when new balls start.