### PR TITLE
Segment Display Emulator Full Color and Mask Flashing Mode

### DIFF
--- a/mpfmc/integration/machine_files/segment_display_emulator/config/config.yaml
+++ b/mpfmc/integration/machine_files/segment_display_emulator/config/config.yaml
@@ -52,6 +52,7 @@ segment_display_player:
   update_segment_display_1:
     display1:
       text: "HELLO"
+      color: FF0000,00FF00,0000FF,FFFF00,00FFFF,FF00FF,FFFFFF
   update_segment_display_2:
     display2:
       text: "IGNORE"

--- a/mpfmc/integration/machine_files/segment_display_emulator/config/config.yaml
+++ b/mpfmc/integration/machine_files/segment_display_emulator/config/config.yaml
@@ -63,3 +63,9 @@ segment_display_player:
     display1:
       action: set_color
       color: "FF0000"
+  update_segment_display_5:
+    display1:
+      text: "SCROLL"
+      transition:
+        type: push
+        direction: right

--- a/mpfmc/integration/test_SegmentDisplayEmulator.py
+++ b/mpfmc/integration/test_SegmentDisplayEmulator.py
@@ -13,7 +13,7 @@ class TestSegmentDisplayEmulator(MpfIntegrationTestCase, MpfFakeGameTestCase, Mp
 
     def test_segment_display_widget(self):
         """Integration test to test segment_display_player in MPF updating segment display widget in MC"""
-        self.advance_time_and_run(1000)
+        self.advance_time_and_run()
         self.assertTextOnTopSlide("")
 
         self.post_event("update_segment_display_1")

--- a/mpfmc/integration/test_SegmentDisplayEmulator.py
+++ b/mpfmc/integration/test_SegmentDisplayEmulator.py
@@ -13,6 +13,7 @@ class TestSegmentDisplayEmulator(MpfIntegrationTestCase, MpfFakeGameTestCase, Mp
 
     def test_segment_display_widget(self):
         """Integration test to test segment_display_player in MPF updating segment display widget in MC"""
+        self.advance_time_and_run(1000)
         self.assertTextOnTopSlide("")
 
         self.post_event("update_segment_display_1")
@@ -23,6 +24,10 @@ class TestSegmentDisplayEmulator(MpfIntegrationTestCase, MpfFakeGameTestCase, Mp
         self.post_event("update_segment_display_2")
         self.advance_time_and_run()
         self.assertTextOnTopSlide("HELLO")
+
+        self.post_event("update_segment_display_5")
+        self.advance_time_and_run()
+        self.assertTextOnTopSlide("SCROLL")
 
         self.post_event("update_segment_display_3")
         self.advance_time_and_run()

--- a/mpfmc/tests/machine_files/segment_display_widget/config/test_segment_display_widget.yaml
+++ b/mpfmc/tests/machine_files/segment_display_widget/config/test_segment_display_widget.yaml
@@ -39,7 +39,7 @@ widgets:
     segment_width: 0.11
     segment_interval: 0.04
     segment_off_color: 4b4c4a30
-    segment_on_color: f01020ff
+    segment_on_color: f01020ff,f01020ff,f01020ff,f01020ff,f01020ff,f01020ff,f01020ff,008000ff
     side_bevel_enabled: true
     flash_mode: "mask"
     flash_mask: "_______F"

--- a/mpfmc/tests/test_SegmentDisplayEmulatorWidget.py
+++ b/mpfmc/tests/test_SegmentDisplayEmulatorWidget.py
@@ -33,7 +33,8 @@ class TestSegmentDisplayEmulatorWidget(MpfMcTestCase):
         self.advance_real_time(0.033)
         self.mc.events.post('update_segment_display', segment_display_name='display2', text='\x12\x11              ')
         self.advance_real_time(0.033)
-        self.mc.events.post('update_segment_display', segment_display_name='display2', text='\x13\x12\x11             ')
+        self.mc.events.post('update_segment_display', segment_display_name='display2',
+                            text='\x13\x12\x11             ')
         self.advance_real_time(0.033)
         self.mc.events.post('update_segment_display', segment_display_name='display2',
                             text='\x13\x13\x12\x11            ')

--- a/mpfmc/widgets/segment_display_emulator.py
+++ b/mpfmc/widgets/segment_display_emulator.py
@@ -146,8 +146,9 @@ class SegmentDisplayEmulator(Widget):
 
         return modified_points
 
-    def _recalculate(self):
+    def _recalculate(self, *args):
         """Recalculate the segments and redraw the display widget."""
+        del args
         self._calculate_segment_points()
         self._draw_widget()
 
@@ -392,7 +393,7 @@ class SegmentDisplayEmulator(Widget):
             if 'text' in kwargs:
                 self.text = kwargs['text']
             if 'color' in kwargs:
-                self.segment_on_color = get_color_from_hex(kwargs['color'])
+                self.segment_on_color = get_color_from_hex(kwargs['color'].pop(0))
             if 'flashing' in kwargs:
                 if kwargs['flashing'] == "False":
                     self.flash_mode = "off"

--- a/mpfmc/widgets/segment_display_emulator.py
+++ b/mpfmc/widgets/segment_display_emulator.py
@@ -486,8 +486,9 @@ class SegmentDisplayEmulator(Widget):
 
         return encoded_characters
 
-    def _set_flash_mode(self):
+    def _set_flash_mode(self, *args):
         """Set the current flash mode."""
+        del args
         if self.flash_mode == "off":
             self._flash_character_mask = [0xFF] * self.character_count
             self._stop_flash_timer()
@@ -501,10 +502,7 @@ class SegmentDisplayEmulator(Widget):
         elif self.flash_mode == "mask":
             mask = self.flash_mask.rjust(self.character_count, ' ')
             mask = mask[-self.character_count:]
-            self._flash_character_mask = [0x00 if c == "F" else 0xFF for c in mask]
-            for index, char in enumerate(mask):
-                if char == "F":
-                    self._flash_character_mask[index] = 0x00
+            self._flash_character_mask = [0x00 if char == "F" else 0xFF for char in mask]
             self._start_flash_timer()
 
     def _start_flash_timer(self):

--- a/mpfmc/widgets/segment_display_emulator.py
+++ b/mpfmc/widgets/segment_display_emulator.py
@@ -10,6 +10,8 @@ from kivy.graphics import Color, Rotate, Scale
 from kivy.utils import get_color_from_hex
 
 from mpf.core.segment_mappings import FOURTEEN_SEGMENTS, SEVEN_SEGMENTS
+from mpf.core.utility_functions import Util
+
 from mpfmc.uix.widget import Widget
 
 MYPY = False
@@ -52,6 +54,10 @@ class SegmentDisplayEmulator(Widget):
             for k, v in self.config["character_map"].items():
                 self._segment_map[k] = v
 
+        # The initial value for segment_on_color is typically set using the config file which creates
+        # a list of lists. A flat one-dimensional list is required so flatten the initial list.
+        self.segment_on_color = list(Util.flatten_list(self.segment_on_color))
+
         # Initialize the encoded display characters
         self._encoded_characters = [OFF] * self.character_count
 
@@ -70,7 +76,7 @@ class SegmentDisplayEmulator(Widget):
                   size=self._recalculate,
                   background_color=self._draw_widget,
                   segment_off_color=self._draw_widget,
-                  segment_on_color=self._draw_widget,
+                  segment_on_color=self._set_character_colors,
                   segment_width=self._recalculate,
                   segment_interval=self._recalculate,
                   bevel_width=self._recalculate,
@@ -79,6 +85,7 @@ class SegmentDisplayEmulator(Widget):
                   character_spacing=self._recalculate)
 
         self._calculate_segment_points()
+        self._set_character_colors()
         self._update_text()
         self._set_flash_mode()
 
@@ -356,23 +363,24 @@ class SegmentDisplayEmulator(Widget):
             x_offset = self.x + self.padding
             y_offset = self.y + self.padding
 
-            for encoded_char in encoded_characters:
+            for index, encoded_char in enumerate(encoded_characters):
 
                 colors = [None] * (self._segment_count + 2)
                 mesh_objects = [None] * self._segment_count
                 for segment in range(self._segment_count):
-                    colors[segment] = self._create_segment_color(segment, encoded_char)
+                    colors[segment] = self._create_segment_color(index, segment, encoded_char)
                     mesh_objects[segment] = self._create_segment_mesh_object(segment, x_offset, y_offset)
 
                 self._segment_colors.append(colors)
                 self._segment_mesh_objects.append(mesh_objects)
                 if self.dot_enabled:
-                    colors[self._dot_segment_index] = self._create_segment_color(self._dot_segment_index, encoded_char)
+                    colors[self._dot_segment_index] = self._create_segment_color(index, self._dot_segment_index,
+                                                                                 encoded_char)
                     Ellipse(pos=(self._dot_points[0] + x_offset, self._dot_points[1] + y_offset),
                             size=(self._dot_points[2], self._dot_points[2]))
 
                 if self.comma_enabled:
-                    colors[self._comma_segment_index] = self._create_segment_color(self._comma_segment_index,
+                    colors[self._comma_segment_index] = self._create_segment_color(index, self._comma_segment_index,
                                                                                    encoded_char)
                     Mesh(vertices=[self._comma_points[0] + x_offset, self._comma_points[1] + y_offset, 0, 0,
                                    self._comma_points[2] + x_offset, self._comma_points[3] + y_offset, 0, 0,
@@ -392,8 +400,11 @@ class SegmentDisplayEmulator(Widget):
         if segment_display_name == self.config['name']:
             if 'text' in kwargs:
                 self.text = kwargs['text']
-            if 'color' in kwargs:
-                self.segment_on_color = get_color_from_hex(kwargs['color'].pop(0))
+            if 'colors' in kwargs and kwargs['colors']:
+                colors = []
+                for color in kwargs['colors']:
+                    colors.extend(get_color_from_hex(color))
+                self.segment_on_color = colors
             if 'flashing' in kwargs:
                 if kwargs['flashing'] == "False":
                     self.flash_mode = "off"
@@ -415,11 +426,11 @@ class SegmentDisplayEmulator(Widget):
                                                           self.comma_enabled, 1 << self._comma_segment_index)
         self._draw_widget()
 
-    def _create_segment_color(self, segment: int, char_code: int):
+    def _create_segment_color(self, index: int, segment: int, char_code: int):
         """Creates a Color vertex instruction for the specified segment number"""
         if (1 << segment) & char_code:
-            return Color(self.segment_on_color[0], self.segment_on_color[1], self.segment_on_color[2],
-                         self.segment_on_color[3])
+            return Color(self.segment_on_color[index * 4], self.segment_on_color[index * 4 + 1],
+                         self.segment_on_color[index * 4 + 2], self.segment_on_color[index * 4 + 3])
         return Color(self.segment_off_color[0], self.segment_off_color[1], self.segment_off_color[2],
                      self.segment_off_color[3])
 
@@ -441,9 +452,10 @@ class SegmentDisplayEmulator(Widget):
         """Update the colors for every segment (on or off based on actual characters)."""
         for char_index in range(self.character_count):
             char_code = self._encoded_characters[char_index]
+            on_color = self._character_colors[char_index * 4:char_index * 4 + 4]
             for segment in range(16):
                 if (1 << segment) & char_code:
-                    self._segment_colors[char_index][segment].rgba = self.segment_on_color
+                    self._segment_colors[char_index][segment].rgba = on_color
                 else:
                     self._segment_colors[char_index][segment].rgba = self.segment_off_color
 
@@ -485,6 +497,19 @@ class SegmentDisplayEmulator(Widget):
             encoded_characters.insert(0, OFF)
 
         return encoded_characters
+
+    def _set_character_colors(self, *args):
+        """Set the segment on/active colors for each character in the display."""
+        del args
+        self._character_colors = self.segment_on_color
+        color_count = int(len(self._character_colors) / 4)
+
+        # fill the rest of the character colors with the last color
+        if color_count < self.character_count:
+            last_color = self._character_colors[-4:]
+            self._character_colors.extend(last_color * (self.character_count - color_count))
+
+        self._draw_widget()
 
     def _set_flash_mode(self, *args):
         """Set the current flash mode."""
@@ -607,7 +632,10 @@ class SegmentDisplayEmulator(Widget):
     '''
 
     segment_on_color = ListProperty([0.867, 0.510, 0.090, 1.0])
-    '''The color of a segment that is on, in the (r, g, b, a) format.
+    '''The color of a segment that is on, in the (r, g, b, a) format. When there is only one color in
+    the list, all characters will use that color. The list can be extended to set a color for each
+    character in the display. If there are fewer colors than characters, the last color in the list
+    will be extended to the remaining characters.
 
     :attr:`segment_on_color` is a :class:`~kivy.properties.ListProperty` and
     defaults to [0.867, 0.510, 0.090, 1.0].

--- a/mpfmc/widgets/segment_display_emulator.py
+++ b/mpfmc/widgets/segment_display_emulator.py
@@ -67,10 +67,16 @@ class SegmentDisplayEmulator(Widget):
         self.bind(text=self._update_text,
                   flash_mode=self._set_flash_mode,
                   pos=self._draw_widget,
-                  size=self._draw_widget,
+                  size=self._recalculate,
                   background_color=self._draw_widget,
                   segment_off_color=self._draw_widget,
-                  segment_on_color=self._draw_widget)
+                  segment_on_color=self._draw_widget,
+                  segment_width=self._recalculate,
+                  segment_interval=self._recalculate,
+                  bevel_width=self._recalculate,
+                  side_bevel_enabled=self._recalculate,
+                  character_slant_angle=self._recalculate,
+                  character_spacing=self._recalculate)
 
         self._calculate_segment_points()
         self._update_text()
@@ -139,6 +145,11 @@ class SegmentDisplayEmulator(Widget):
             modified_points.append(points[index + 1])
 
         return modified_points
+
+    def _recalculate(self):
+        """Recalculate the segments and redraw the display widget."""
+        self._calculate_segment_points()
+        self._draw_widget()
 
     def _calculate_segment_points(self):
         """Calculate the points of all the display segments to be drawn."""
@@ -381,8 +392,19 @@ class SegmentDisplayEmulator(Widget):
             if 'text' in kwargs:
                 self.text = kwargs['text']
             if 'color' in kwargs:
-                self.segment_on_color = get_color_from_hex(kwargs['color'].pop())
-            # todo: update flash
+                self.segment_on_color = get_color_from_hex(kwargs['color'])
+            if 'flashing' in kwargs:
+                if kwargs['flashing'] == "False":
+                    self.flash_mode = "off"
+                elif kwargs['flashing'] == "True":
+                    self.flash_mode = "all"
+                elif kwargs['flashing'] == "match":
+                    self.flash_mode = "match"
+                elif kwargs['flashing'] == "mask":
+                    self.flash_mask = kwargs.get('flash_mask', "")
+                    self.flash_mode = "mask"
+                else:
+                    self.flash_mode = "off"
 
     def _update_text(self, *args):
         """Process the new text value to prepare it for display"""


### PR DESCRIPTION
This PR adds full color support for each character in the segment_display_emulator widget. In addition all flashing modes in MPF are now supported using the virtual segment display emulator connector plugin, including the new Mask flashing mode. This PR requires MPF PR 1565 (https://github.com/missionpinball/mpf/pull/1565).