### PR TITLE
Add support for widget_styles in modes

### DIFF
--- a/mpfmc/tests/machine_files/widget_styles/config/test_widget_styles.yaml
+++ b/mpfmc/tests/machine_files/widget_styles/config/test_widget_styles.yaml
@@ -2,6 +2,7 @@
 
 modes:
   - mode1
+  - mode2
 
 displays:
   default:

--- a/mpfmc/tests/machine_files/widget_styles/modes/mode1/config/mode1.yaml
+++ b/mpfmc/tests/machine_files/widget_styles/modes/mode1/config/mode1.yaml
@@ -6,6 +6,8 @@ mode:
 widget_styles:
   text_default:
     font_size: 50
+  smallStyle:
+    font_size: 25
 
 slides:
   slide2:
@@ -13,9 +15,12 @@ slides:
       text: MODE1 DEFAULT STYLE
       y: 75
     - type: text
-      style: big
+      style: bigStyle
       text: BIG FROM BASE
       y: 225
+    - type: text
+      style: smallStyle
+      text: SMALL FROM MODE
 
 slide_player:
   slide2: slide2

--- a/mpfmc/tests/machine_files/widget_styles/modes/mode2/config/mode2.yaml
+++ b/mpfmc/tests/machine_files/widget_styles/modes/mode2/config/mode2.yaml
@@ -1,0 +1,8 @@
+#config_version=5
+
+mode:
+  priority: 200
+
+widget_styles:
+  smallStyle:
+    font_size: 20

--- a/mpfmc/tests/test_WidgetStyles.py
+++ b/mpfmc/tests/test_WidgetStyles.py
@@ -61,22 +61,47 @@ class TestWidgetStyles(MpfMcTestCase):
         self.assertEqual(self.get_widget().font_size, 21)
         self.assertEqual(self.get_widget().color, [0.0, 0.0, 1.0, 1]);
 
-    # todo some future release
+    def test_mode_style(self):
+        self.mc.modes['mode1'].start()
+        self.advance_time()
+    
+        self.mc.events.post('slide2')
+        self.advance_time()
+    
+        # widget with no style, should pickup default out of the mode
+        # text_strings, rather than the machine wide one
+        self.assertEqual(self.get_widget().font_size, 50)
+    
+        # mode widget with style from machine wide config
+        self.assertEqual(self.get_widget(1).font_size, 100)
+    
+        # mode widget with style from mode config
+        self.assertEqual(self.get_widget(2).font_size, 25)
 
-    # def test_mode_style(self):
-    #     self.mc.modes['mode1'].start()
-    #     self.advance_time()
-    #
-    #     self.mc.events.post('slide2')
-    #     self.advance_time()
-    #
-    #     # widget with no style, should pickup default out of the mode
-    #     # text_strings, rather than the machine wide one
-    #     self.assertEqual(self.get_widget().font_size, 50)
-    #
-    #     # mode widget with style from machine wide config
-    #     self.assertEqual(self.get_widget(1).font_size, 100)
-    #
-    #     # mode widget with style name that's not valid, so it should
-    #     # pickup the default
-    #     self.assertEqual(self.get_widget(2).font_size, 50)
+    def test_mode_style_priority_12(self):
+        # modes started in priority order
+        self.mc.modes['mode1'].start()
+        self.advance_time()
+    
+        self.mc.modes['mode2'].start()
+        self.advance_time()
+
+        self.mc.events.post('slide2')
+        self.advance_time()
+
+        # should use style from mode 2
+        self.assertEqual(self.get_widget(2).font_size, 20)
+
+    def test_mode_style_priority_21(self):
+        # modes started in reverse priority order
+        self.mc.modes['mode2'].start()
+        self.advance_time()
+    
+        self.mc.modes['mode1'].start()
+        self.advance_time()
+
+        self.mc.events.post('slide2')
+        self.advance_time()
+
+        # should use style from mode 2
+        self.assertEqual(self.get_widget(2).font_size, 20)

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -372,7 +372,7 @@ class Widget(KivyWidget):
         """Sets the default widget style name."""
         name = '{}_default'.format(self.widget_type_name.lower())
         try:
-            self._default_style = self._lookup_style(name) 
+            self._default_style = self._lookup_style(name)
         except KeyError:
             pass
 


### PR DESCRIPTION
Add support for widget_styles in mode configurations. 

I am creating a score display and the configuration would fail when putting widget_styles in the mode configuration but would work when placed in the machine config. It looks like support for modes was planned, but not added, as there are a few tests for this feature that are commented out. 

Added a _lookup_style method that first checks the active modes, in order, for a matching widget_style. If not found the style lookup is then performed on the machine configuration. 

An example of this working can be found here:

https://github.com/drop-target-pinball/mpf-sandbox/tree/main/score-display

In that directory, run `mpf both -X` and press 'S' to start. It will crash because the style cannot be found. It should work when using the changes on this branch. 

One of the tests that were commented out was to check that the default style is used when the specified style cannot be found. The current code seems to prefer raising an error instead so that test has been removed. 

Let me know if you have any questions or change requests.

