### PR TITLE
Initialize audio master_volume from machine variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ before_script:
       export FFLAGS=-ff2c;
       export KIVY_GL_BACKEND=mock;
     fi;
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ] && [ ! -z "${DOCKER_PASSWORD}" ]; then; then
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ] && [ ! -z "${DOCKER_PASSWORD}" ]; then
       echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin;
     fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ before_script:
       export FFLAGS=-ff2c;
       export KIVY_GL_BACKEND=mock;
     fi;
-  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ] && [ ! -z "${DOCKER_PASSWORD}" ]; then; then
       echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin;
     fi;
 

--- a/mpfmc/core/audio/__init__.py
+++ b/mpfmc/core/audio/__init__.py
@@ -117,7 +117,13 @@ class SoundSystem:
         self.mc.events.add_handler("master_volume_increase", self.master_volume_increase)
         self.mc.events.add_handler("master_volume_decrease", self.master_volume_decrease)
         self.mc.events.add_handler("shutdown", self.shutdown)
-        self.mc.events.add_handler("client_connected", self._send_volume, -1)
+        self.mc.events.add_handler("machine_var_master_volume", self._get_initial_volume)
+
+    def _get_initial_volume(self, **kwargs):
+        self.master_volume = kwargs['value']
+        # Subsequent volume changes will be pushed to MPF and bounced back,
+        # but there's no reason to keep listening
+        self.mc.events.remove_handler(self._get_initial_volume)
 
     def _send_volume(self, **kwargs):
         del kwargs

--- a/mpfmc/uix/widget.py
+++ b/mpfmc/uix/widget.py
@@ -459,9 +459,9 @@ class Widget(KivyWidget):
             val = percent_to_float(val, self._percent_prop_dicts[prop])
         except KeyError:
             # because widget properties can include a % sign, they are
-            # all strings, so even ones that aren't on the list to look
+            # often strings, so even ones that aren't on the list to look
             # for percent signs have to be converted to numbers.
-            if '.' in val:
+            if '.' in str(val):
                 val = float(val)
             else:
                 val = int(val)


### PR DESCRIPTION
This PR changes the Audio behavior to allow persisted master_volume settings across games.

In the current behavior, the Audio controller initializes with either a default or config value for the MC `master_volume` and upon BCP connection, pushes that value to MPF to be stored as a machine variable.

With this PR, the Audio controller waits for BCP connection and the automatic dump of machine variables from MPF, and then sets the MC `master_volume` accordingly. 

In order to ensure that a volume is set, https://github.com/missionpinball/mpf/pull/1580 establishes a default `master_volume` definition in the MPF machine variables. 


_Also, this PR includes a bugfix on the widgets where some event-based widgets would crash because they received a non-string value. Coercing the value to a string prevents this._