### PR TITLE
Remove MPF as a package requirement

### DIFF
--- a/mpfmc/_version.py
+++ b/mpfmc/_version.py
@@ -1,13 +1,13 @@
-__version__ = '0.56.0-dev33'
+__version__ = '0.56.0-dev34'
 __short_version__ = '0.56'
 __bcp_version__ = '1.1'
 __config_version__ = '5'
 __mpf_version_required__ = '0.56.0-dev33'
 
 # pylint: disable-msg=invalid-name
-version = "MPF-MC v{}".format(__version__)
+version = f"MPF-MC v{__version__}"
 '''A friendly version string for this build of MPF.'''
 
 # pylint: disable-msg=invalid-name
-extended_version = "MPF-MC v{} (config_version={}, BCP v{}, Requires MPF v{})".format(
-    __version__, __config_version__, __bcp_version__, __mpf_version_required__)
+extended_version = f"MPF-MC v{__version__} (config_version={__config_version__}, BCP v{__bcp_version__}, \
+                     Requires MPF API compatibility v{ __mpf_version_required__} or newer)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers=[
     ]
 dependencies = [
     "ruamel.yaml == 0.15.42",  # newer than this requires c requires compiled c lib, currently no Mac arm versions
-    "mpf >= 0.56.0dev1", # {attr = "mpfmc._version.__mpf_version_required__"},
     "kivy >=2.0.0",
     "psutil ==5.9.1",
     "Pygments >=2.6.1",


### PR DESCRIPTION
Removed `mpf` as a package requirement, which will allow MPF-MC to be used with any package which provides an mpf-compattible API. If MPF-MC is installed and MPF isn't there, then the "mpf both" or "mpf mc" commands won't work, but once MPF or an MPF-compatible engine is installed, then those entry points will function as expected.