### PR TITLE
Suppress kivy white no-texture display when videos load slow

### DIFF
--- a/mpfmc/widgets/video.py
+++ b/mpfmc/widgets/video.py
@@ -76,10 +76,11 @@ class VideoWidget(Widget, Video):
 
         if self.state in ('play', 'pause'):
             with self.canvas:
-                Color(*self.color)
-                Rotate(angle=self.rotation, origin=anchor)
-                Scale(self.scale).origin = anchor
-                Rectangle(pos=self.pos, size=self.size, texture=self.texture)
+                if self.texture:
+                    Color(*self.color)
+                    Rotate(angle=self.rotation, origin=anchor)
+                    Scale(self.scale).origin = anchor
+                    Rectangle(pos=self.pos, size=self.size, texture=self.texture)
 
     def _setup_control_events(self, event_list: list) -> None:
         for entry in event_list:

--- a/mpfmc/widgets/video.py
+++ b/mpfmc/widgets/video.py
@@ -78,9 +78,13 @@ class VideoWidget(Widget, Video):
             with self.canvas:
                 if self.texture:
                     Color(*self.color)
-                    Rotate(angle=self.rotation, origin=anchor)
-                    Scale(self.scale).origin = anchor
-                    Rectangle(pos=self.pos, size=self.size, texture=self.texture)
+
+                else:
+                    Color(0,0,0,1)
+
+                Rotate(angle=self.rotation, origin=anchor)
+                Scale(self.scale).origin = anchor
+                Rectangle(pos=self.pos, size=self.size, texture=self.texture)
 
     def _setup_control_events(self, event_list: list) -> None:
         for entry in event_list:


### PR DESCRIPTION
A proposed fix for the white flash some people see on slower I/O machines as a video loads.   In the current code, the _draw_widget method creates the rectangle for the video even if the texture isn't loaded.   this event is also called a lot as the video is set up, so my change just sets the color of the canvas to fully opaque black while the video is loading, which suppresses the white flash from the stock kivy behavior when the video texture isnt loaded yet.  Once the texture has been set, this method fires again anyway because of other variables changing and will proceed with the color set the way mpf-mc did it prior to this change.



