### PR TITLE
Allow missing mode folders in production mode

### DIFF
--- a/mpfmc/core/mode_controller.py
+++ b/mpfmc/core/mode_controller.py
@@ -101,7 +101,8 @@ class ModeController:
                 self._machine_mode_folders[mode_string])
             asset_paths.append(mode_path)
 
-        if not mode_path:
+        # Production builds do not require paths for all modes
+        if not mode_path and not self.mc.options['production']:
             raise ValueError("No folder found for mode '{}'. Is your mode "
                              "folder in your machine's 'modes' folder?"
                              .format(mode_string))


### PR DESCRIPTION
This PR makes a small change to running MPF MC in `production` mode for optimized performance. During the production build, mode config files are consolidated into a single bundle and individual mode folders with _modes/<mode_name>/config/<mode_name>.yaml_ files are not necessary.

Without the need for individual config files, the exported machine code does not need separate folders for all modes. MPF manages just fine in this way, but MC throws on bootup because the mode folders are empty. This PR changes the MC startup code to allow missing mode folders while in production mode.

**Caveat:** Modes that have specific media assets, like `sounds:` or `videos:` still require having a mode folder with those subfolders for the assets. If the root mode folder is missing, skipping this check will expose a downstream error where an expected media file is missing. Perhaps an error on the media file instead of the mode folder is less helpful, but given the constraints I'm okay with it.

![where is it?](https://media.giphy.com/media/g01ZnwAUvutuK8GIQn/giphy-downsized.gif)