### PR TITLE
🍒 Cherry Pick #452 fix for windows audio issue to 0.56

### DIFF
--- a/mpfmc/core/mc.py
+++ b/mpfmc/core/mc.py
@@ -48,13 +48,20 @@ from mpfmc.core.mc_placeholder_manager import McPlaceholderManager
 from mpfmc.core.mc_settings_controller import McSettingsController
 
 try:
-    from mpfmc.core.audio import SoundSystem
+    # The following two lines are needed because of circular dependencies.
+    # These Cython based imports also import assets.sound which then import these (causing a loop/circle).
+    # Loading these first resolves an issue on Windows that otherwise causes audio to not load.
+    from mpfmc.core.audio.audio_interface import AudioInterface
+    from mpfmc.core.audio.audio_exception import AudioException
+
     from mpfmc.assets.sound import SoundAsset
-except ImportError:
+    from mpfmc.core.audio import SoundSystem
+except ImportError as e:
     SoundSystem = None
     SoundAsset = None
-    logging.warning("mpfmc.core.audio library could not be loaded. Audio "
-                    "features will not be available")
+    logging.warning("Error importing MPF-MC audio library. Audio will be disabled.")
+    logging.warning("*** [[[[[[[[[[[[[[[[[[[ NO AUDIO ]]]]]]]]]]]]]]]]] ***")
+    logging.exception(str(e))
 
 # The following line is needed to allow mpfmc modules to use the
 # getLogger(name) method


### PR DESCRIPTION
This PR cherry-picks PR #452 into 0.56 release branch to assist folks not yet ready to jump into prerelease 0.57. It bypasses the Windows circular dependency issue on importing audio libraries.

![can you hear me?](https://media.giphy.com/media/u4Kk8AgDsZJX9i4xZT/giphy.gif)