### PR TITLE
0.56.x

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -175,6 +175,11 @@ jobs:
     needs: [test_wheels, make_sdist]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mpf
+    permissions:
+      id-token: write
     steps:
     - name: Download wheels
       uses: actions/download-artifact@v3
@@ -182,10 +187,7 @@ jobs:
         name: mpf-mc_wheels
         path: dist
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.5.0
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1
 
   coveralls:
     name: Finalize Coveralls

--- a/mpfmc/_version.py
+++ b/mpfmc/_version.py
@@ -1,4 +1,4 @@
-__version__ = '0.56.1'
+__version__ = '0.56.2'
 __short_version__ = '0.56'
 __bcp_version__ = '1.1'
 __config_version__ = '5'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "kivy_deps.sdl2 == 0.4.5; platform_system=='Windows'",  # Feb 15, 2022. 0.5.0 (Sept 2002) and 0.5.1 (Oct 2022) cause audio playback issues
     "kivy_deps.glew == 0.3.1; platform_system=='Windows'",  # Feb 15, 2022
     "kivy_deps.gstreamer == 0.3.3; platform_system=='Windows'",  # Jan 11, 2022
-    "ffpyplayer == 4.3.5"  # Mar 29, 2022
+    "ffpyplayer == 4.5.1"  # Jan 11, 2024, needed for RPi
     ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Updated to require ffpyplayer version 4.5.1 to allow for install on RPi. Saw this was [already done for 0.57](https://github.com/missionpinball/mpf-mc/blob/69aa78b1f0c41c367b3b1d2fd0568a66c262284e/pyproject.toml#L29). 