### PR TITLE
Audio track volume control and SoundPlayer ducking

### DIFF
--- a/mpfmc/assets/sound.py
+++ b/mpfmc/assets/sound.py
@@ -556,6 +556,12 @@ class SoundAsset(McAsset):
         """Return whether or not this sound has ducking"""
         return self._ducking is not None
 
+    def set_ducking(self, ducking_settings=None):
+        if not ducking_settings:
+            self._ducking = None
+            return
+        self._ducking = DuckingSettings(self.machine, ducking_settings)
+
     @property
     def key(self):
         """Return the unique key value for this sound"""

--- a/mpfmc/config_players/slide_player.py
+++ b/mpfmc/config_players/slide_player.py
@@ -102,7 +102,7 @@ class McSlidePlayer(McConfigPlayer):
         instance_dict = self._get_instance_dict(context)
         full_context = self._get_full_context(context)
 
-        self.machine.log.info("SlidePlayer: Play called with settings=%s", settings)
+        self.machine.log.debug("SlidePlayer: Play called with settings=%s", settings)
 
         settings = settings.get('slides', settings)
 

--- a/mpfmc/config_players/sound_player.py
+++ b/mpfmc/config_players/sound_player.py
@@ -75,13 +75,16 @@ Here are several various examples:
         action:
         priority:
         volume:
+        ducking:
         loops:
         max_queue_time:
         block:
 
         Notes:
-            Ducking settings and markers cannot currently be specified/overridden in the
-            sound_player (they must be specified in the sounds section of a config file).
+         -  Ducking settings only apply to sound assets without ducking config
+            (i.e. sound asset ducking overrides sound_player ducking)
+         -  Markers cannot currently be specified/overridden in the sound_player
+            (they must be specified in the sounds section of a config file).
 
         """
         settings = deepcopy(settings)
@@ -135,7 +138,15 @@ Here are several various examples:
 
             # Determine action to perform
             if action == 'play':
+                temp_ducking = None
+                if s.get('ducking') and not sound.has_ducking:
+                    sound.set_ducking(s['ducking'])
+                    temp_ducking = True
+
                 track.play_sound(sound, context, s)
+                # Remove the temporary ducking
+                if temp_ducking:
+                    sound.set_ducking()
 
             elif action == 'stop':
                 if 'fade_out' in s:

--- a/mpfmc/core/audio/__init__.py
+++ b/mpfmc/core/audio/__init__.py
@@ -115,9 +115,18 @@ class SoundSystem:
 
         self.mc.events.add_handler("shutdown", self.shutdown)
         self.mc.events.add_handler("machine_var_master_volume", self._set_volume)
+        for track in self.tracks.keys():
+            self.mc.events.add_handler(f"machine_var_{track}_volume", self._set_volume, track=track)
 
     def _set_volume(self, **kwargs):
-        self.master_volume = kwargs['value']
+        track = kwargs.get("track")
+        if not track:
+            self.master_volume = kwargs['value']
+            return
+        elif not track in self.tracks:
+            raise AttributeError(f"Track {track} not found in sound system.")
+
+        self.tracks[track].set_volume(kwargs['value'])
 
     def shutdown(self, **kwargs):
         """Shuts down the audio interface"""

--- a/mpfmc/tests/test_Display.py
+++ b/mpfmc/tests/test_Display.py
@@ -1,3 +1,4 @@
+from kivy.metrics import dp
 from mpfmc.uix.display import Display, DisplayOutput
 from mpfmc.tests.MpfMcTestCase import MpfMcTestCase
 
@@ -11,12 +12,14 @@ class TestDisplay(MpfMcTestCase):
 
     def test_display(self):
         # Make sure nested multiple displays are loaded properly and are centered
-        self.assertEqual(self.mc.root_window.size, (800, 600))
+        self.assertEqual(self.mc.root_window.system_size, [800, 600])
         self.assertIn('window', self.mc.displays)
         self.assertTrue(isinstance(self.mc.displays['window'], Display))
         self.assertEqual(self.mc.displays['window'].size, [600, 200])
         self.assertIsInstance(self.mc.displays['window'].parent, DisplayOutput)
-        self.assertEqual(self.mc.displays['window'].parent.pos, (0, 167))
+        self.assertEqual(self.mc.displays['window'].parent.pos[0], 0)
+        # Rounding DPI can cause single pixel offset, so accept within 1px
+        self.assertAlmostEqual(self.mc.displays['window'].parent.pos[1], dp(167), delta=1)
 
         self.assertIn('dmd', self.mc.displays)
         self.assertTrue(isinstance(self.mc.displays['dmd'], Display))


### PR DESCRIPTION
Reverts missionpinball/mpf-mc#462 and reinstates https://github.com/missionpinball/mpf-mc/pull/459

### Audio Track Volume Control

This PR extends the audio tracks (defined in `sound_system: tracks:`) to have discrete volume levels that can be controlled from the Service Audio Menu (https://github.com/missionpinball/mpf/pull/1743). Each track can already have a separate volume level, but with this PR that level is adjustable via menu and automatically persisted as a machine var, to allow fine-tuning of relative track levels during gameplay.

### SoundPlayer Ducking

This PR adds support for `ducking` arguments in SoundPlayer, so ducking can be defined at the player level instead of on each individual sound file separately. This is intended as a broad-strokes approach to provide basic ducking quickly, and is not nearly as accurate as defining ducking to each sound specifically. With this in mind, for any sound that has its own `ducking:` defined that sound's ducking will take priority over the SoundPlayer ducking.

### SlidePlayer Logging

This PR reduces the log level of the SlidePlayer from INFO to DEBUG, because during a game lots of slides are played and the logging for slides is bulky. SlidePlayer logs to the machine log, so it's log level cannot be configured separately from the general machine. After this change, the SlidePlayer logs will still appear in verbose mode.

![turn it up!](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExN3kyM2ZwY2ZscXZzcTFoYnMxajFvaDlkcTNvcTUyMWIycXo4ZXV1MyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26FfgDrbYsfGxxpW8/giphy.gif) 