### PR TITLE
Bump psutil from 5.9.5 to 5.9.8

### DIFF
--- a/mpfmc/_version.py
+++ b/mpfmc/_version.py
@@ -1,10 +1,10 @@
 import os
 
-__version__ = '0.57.0.dev13'
+__version__ = '0.57.0.dev14'
 __short_version__ = '0.57'
 __bcp_version__ = '1.1'
 __config_version__ = '6'
-__mpf_version_required__ = '0.57.0.dev34'  # ALSO UPDATE in pyproject.toml
+__mpf_version_required__ = '0.57.0.dev40'  # ALSO UPDATE in pyproject.toml
 
 # pylint: disable-msg=invalid-name
 version = f"MPF-MC v{__version__}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers=[
 dependencies = [
     "mpf >= 0.57.0.dev34",  # ALSO CHANGE THIS IN _version.py
     "kivy == 2.2.1",  # Sept 19, 2023  # ALSO CHECK for updates to kivy_deps packages below
-    "psutil == 5.9.5",  # Sept 19, 2023
+    "psutil == 5.9.8",  # Sept 19, 2023
     "Pygments == 2.16.1", # Sept 19, 2023  Only used for the interactive MC. Does anyone use that?
     "ffpyplayer == 4.5.1",  # Nov 3, 2023  4.5.1 needed for RPi.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers=[
     "Topic :: Games/Entertainment :: Arcade"
     ]
 dependencies = [
-    "mpf >= 0.57.0.dev34",  # ALSO CHANGE THIS IN _version.py
+    "mpf >= 0.57.0.dev40",  # ALSO CHANGE THIS IN _version.py
     "kivy == 2.2.1",  # Sept 19, 2023  # ALSO CHECK for updates to kivy_deps packages below
     "psutil == 5.9.8",  # Sept 19, 2023
     "Pygments == 2.16.1", # Sept 19, 2023  Only used for the interactive MC. Does anyone use that?


### PR DESCRIPTION
This PR bumps psutil dependency to 5.9.8 to align with the same change in MPF: https://github.com/missionpinball/mpf/pull/1773

![dependable](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWQ3MG91N3BpM201OWMxOTF3d3lxeDRpZGtlOWFmODh2NTI1MWFheSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/TR2ojpQzILj0JX4jmV/giphy.gif)