### PR TITLE
Bugfix: Sound player delays dropping subsequent sounds

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run cibuildwheel
-        uses: pypa/cibuildwheel@v2.16.1  # Oct 2, 2023
+        uses: pypa/cibuildwheel@v2.19.2  # Aug 9 2024
         env:
           CIBW_BEFORE_ALL_LINUX: > # This is done here and not as its own step as this runs inside the cibw containered environment
             yum install -y SDL2.x86_64 SDL2-devel.x86_64 SDL2_image.x86_64 SDL2_image-devel.x86_64

--- a/mpfmc/_version.py
+++ b/mpfmc/_version.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = '0.57.0'
+__version__ = '0.57.1'
 __short_version__ = '0.57'
 __bcp_version__ = '1.1'
 __config_version__ = '6'

--- a/mpfmc/config_players/sound_player.py
+++ b/mpfmc/config_players/sound_player.py
@@ -94,7 +94,7 @@ Here are several various examples:
 
         for sound_name, s in settings.items():
             if self.check_delayed_play(sound_name, s, context, calling_context, priority, **kwargs):
-                return
+                continue
 
             # adjust priority
             try:
@@ -108,7 +108,7 @@ Here are several various examples:
             except KeyError:
                 self.machine.log.error("SoundPlayer: The specified sound "
                                        "does not exist ('{}').".format(sound_name))
-                return
+                continue
 
             s.update(kwargs)
 
@@ -122,7 +122,7 @@ Here are several various examples:
                                        "does not exist. Unable to perform '{}' action "
                                        "on sound '{}'."
                                        .format(s['track'], action, sound_name))
-                return
+                continue
 
             # a block will block any other lower priority sound from being triggered by the same event
             # the calling_context contains the name of the triggering event

--- a/mpfmc/mcconfig.yaml
+++ b/mpfmc/mcconfig.yaml
@@ -107,7 +107,7 @@ assets:
             load: mode_start
     images:
         default:
-            load: preload
+            load: on_demand
         preload:
             load: preload
         on_demand:


### PR DESCRIPTION
A bug was discovered in MPF-MC SoundPlayer where adding a sound with `delay` would end the sound player processing loop, potentially discarding additional sounds passed in the same payload.

This is because the delay check calls `return` instead of `continue`, thus aborting the loop through all sounds passed.

This PR changes the call to `continue`, as well as for a few other error checks that also called `return` and would prevent subsequent sounds in the payload from playing.

Manually tested.