### PR TITLE
remove github actions cleverness around mpf version matching

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -183,7 +183,7 @@ jobs:
         fi
 
         python_version_nodot=$(echo "${{ matrix.python-version }}" | tr -d '.')
-        wheel_file=$(ls dist/mpf_mc-*cp${python_version_nodot}-*-${platform}.whl)
+        wheel_file=$(ls dist/mpf_mc-*-cp${python_version_nodot}-*${platform}.whl)
         pip install "$wheel_file"
     - name: Run tests  # Can't figure out how to run tests on mac or windows, but I guess that's ok? At least we test the wheel installs? TODO?
       if: ${{ matrix.run-tests }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -84,8 +84,6 @@ jobs:
             SDL2_mixer.x86_64 SDL2_mixer-devel.x86_64 gstreamer1.x86_64 gstreamer1-devel.x86_64 &&
             python -m pip install --upgrade pip &&
             pip install --upgrade setuptools wheel build &&
-            git clone --recursive --branch ${{ github.ref_name }} https://github.com/missionpinball/mpf.git _mpf ||
-            git clone --recursive --branch `python get_version.py` https://github.com/missionpinball/mpf.git _mpf ||
             git clone --recursive --branch 0.57.x https://github.com/missionpinball/mpf.git _mpf &&
             pip install -e _mpf
           CIBW_BEFORE_ALL_MACOS: >
@@ -93,8 +91,6 @@ jobs:
           CIBW_BEFORE_ALL: >
             python -m pip install --upgrade pip &&
             pip install --upgrade setuptools wheel build &&
-            git clone --recursive --branch ${{ github.ref_name }} https://github.com/missionpinball/mpf.git _mpf ||
-            git clone --recursive --branch `python get_version.py` https://github.com/missionpinball/mpf.git _mpf ||
             git clone --recursive --branch 0.57.x https://github.com/missionpinball/mpf.git _mpf &&
             pip install -e _mpf
           CIBW_BUILD: ${{ matrix.cibw-build }}
@@ -166,11 +162,9 @@ jobs:
       with:
         name: mpf-mc_wheels
         path: dist
-    - name: Clone & install MPF  # try to find a matching version before we default to dev
+    - name: Clone & install MPF
       run: >
-        git clone --recursive --branch ${{ github.ref_name }} https://github.com/missionpinball/mpf.git _mpf ||
-        git clone --recursive --branch `python get_version.py` https://github.com/missionpinball/mpf.git _mpf ||
-        git clone --recursive --branch dev https://github.com/missionpinball/mpf.git _mpf &&
+        git clone --recursive --branch 0.57.x https://github.com/missionpinball/mpf.git _mpf &&
         pip install -e _mpf
     - name: List wheels in dist
       run: ls -l dist

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: mpf-mc_wheels
+          name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
           path: ./wheelhouse/*.whl
 
   make_sdist:
@@ -157,11 +157,13 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools wheel coveralls prospector==1.3.1
+
     - name: Download the newly-built wheel
       uses: actions/download-artifact@v7
       with:
-        name: mpf-mc_wheels
+        name: wheels-${{ matrix.python-version }}-${{ matrix.os }}
         path: dist
+
     - name: Clone & install MPF
       run: >
         git clone --recursive --branch 0.57.x https://github.com/missionpinball/mpf.git _mpf &&
@@ -170,21 +172,8 @@ jobs:
       run: ls -l dist
     - name: Install MPF-MC from new wheel
       shell: bash  # Need bash on windows to use the if statement
+      run: pip install dist/*.whl
 
-      # We need some logic here to force pip to use the new wheel we just built. Otherwise if we're on a pull request, it will try to install from pypi which won't test the new wheel.
-      # We can't use --no-index because we need to install the rest of the dependencies from pypi
-      run: |
-        if [ "${{ runner.os }}" == "Linux" ]; then
-          platform="manylinux_2_17_x86_64.manylinux2014_x86_64"
-        elif [ "${{ runner.os }}" == "macOS" ]; then
-          platform="macosx_10_9_x86_64"
-        elif [ "${{ runner.os }}" == "Windows" ]; then
-          platform="win_amd64"
-        fi
-
-        python_version_nodot=$(echo "${{ matrix.python-version }}" | tr -d '.')
-        wheel_file=$(ls dist/mpf_mc-*-cp${python_version_nodot}-*${platform}.whl)
-        pip install "$wheel_file"
     - name: Run tests  # Can't figure out how to run tests on mac or windows, but I guess that's ok? At least we test the wheel installs? TODO?
       if: ${{ matrix.run-tests }}
       run: |


### PR DESCRIPTION
As MC is becoming stale and harder to get any successful build (steps even) on ci the requirement should be that any changes that MC needs from mpf core MUST land in mpf 0.57.x (or 58+ when we move mc in lockstep) before mc can be built against it.